### PR TITLE
Refactor tracking code generation into shared utility

### DIFF
--- a/server/repositories/ApplicationRepository.ts
+++ b/server/repositories/ApplicationRepository.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client'
 import type { ApplicationRequest, ApplicationResponse, ApplicationStatus } from '../types/api'
+import { generateTrackingCode } from '../utils/tracking'
 
 export class ApplicationRepository {
   constructor(private prisma: PrismaClient) {}
@@ -8,8 +9,8 @@ export class ApplicationRepository {
    * Create a new application
    */
   async create(data: ApplicationRequest): Promise<ApplicationResponse> {
-    // Generate tracking codeё
-    const trackingCode = this.generateTrackingCode()
+    // Generate tracking code
+    const trackingCode = generateTrackingCode()
 
     const application = await this.prisma.application.create({
       data: {
@@ -181,13 +182,4 @@ export class ApplicationRepository {
     }
   }
 
-  /**
-   * Generate unique tracking code
-   */
-  private generateTrackingCode(): string {
-    const prefix = 'EDU'
-    const timestamp = Date.now().toString(36).toUpperCase()
-    const random = Math.random().toString(36).substr(2, 4).toUpperCase()
-    return `${prefix}-${timestamp}-${random}`
-  }
 }

--- a/server/utils/api-helpers.ts
+++ b/server/utils/api-helpers.ts
@@ -1,5 +1,7 @@
 import type { FAQItem, FAQCategory } from '../types/api'
 
+export { generateTrackingCode } from './tracking'
+
 /**
  * Parse query parameters for universities endpoint
  */
@@ -141,16 +143,6 @@ export function calculatePagination(total: number, page: number, limit: number) 
     limit: Math.max(1, limit),
     totalPages: Math.max(1, totalPages)
   }
-}
-
-/**
- * Generate tracking code for applications
- */
-export function generateTrackingCode(): string {
-  const prefix = 'EDU'
-  const timestamp = Date.now().toString(36).toUpperCase()
-  const random = Math.random().toString(36).substr(2, 4).toUpperCase()
-  return `${prefix}-${timestamp}-${random}`
 }
 
 /**

--- a/server/utils/tracking.ts
+++ b/server/utils/tracking.ts
@@ -1,0 +1,6 @@
+export function generateTrackingCode(): string {
+  const prefix = 'EDU'
+  const timestamp = Date.now().toString(36).toUpperCase()
+  const random = Math.random().toString(36).substr(2, 4).toUpperCase()
+  return `${prefix}-${timestamp}-${random}`
+}

--- a/tests/server/tracking.test.ts
+++ b/tests/server/tracking.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { PrismaClient } from '@prisma/client'
+
+import { ApplicationRepository } from '../../server/repositories/ApplicationRepository'
+import { generateTrackingCode as helperGenerateTrackingCode } from '../../server/utils/api-helpers'
+import * as trackingUtils from '../../server/utils/tracking'
+import type { ApplicationRequest } from '../../server/types/api'
+
+describe('tracking code generation', () => {
+
+  it('creates tracking code with EDU prefix via request helper', () => {
+    const trackingCode = helperGenerateTrackingCode()
+
+    expect(trackingCode.startsWith('EDU-')).toBe(true)
+
+    const parts = trackingCode.split('-')
+    expect(parts).toHaveLength(3)
+    expect(parts[1]).toMatch(/^[0-9A-Z]+$/)
+    expect(parts[2]).toMatch(/^[0-9A-Z]{4}$/)
+  })
+
+  it('uses shared tracking generator in repository', async () => {
+    const sharedCode = 'EDU-FAKE-CODE'
+    const generateSpy = vi.spyOn(trackingUtils, 'generateTrackingCode').mockReturnValue(sharedCode)
+
+    const submittedAt = new Date('2024-01-01T00:00:00.000Z')
+    const createMock = vi.fn().mockResolvedValue({
+      id: 42,
+      trackingCode: sharedCode,
+      status: 'submitted',
+      personalInfo: {},
+      education: {},
+      preferences: {},
+      additionalInfo: {},
+      submittedAt
+    })
+
+    const prismaMock = {
+      application: {
+        create: createMock
+      }
+    } as unknown as PrismaClient
+
+    const repository = new ApplicationRepository(prismaMock)
+
+    const request: ApplicationRequest = {
+      personal_info: {
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'john@example.com',
+        phone: '+1234567890'
+      },
+      education: {
+        level: 'Bachelor',
+        field: 'Engineering'
+      },
+      preferences: {},
+      additional_info: 'Interested in scholarships',
+      source: 'website',
+      user_preferences: {}
+    }
+
+    try {
+      const result = await repository.create(request)
+
+      expect(generateSpy).toHaveBeenCalledTimes(1)
+      expect(createMock).toHaveBeenCalledWith({
+        data: {
+          trackingCode: sharedCode,
+          status: 'submitted',
+          personalInfo: request.personal_info,
+          education: request.education,
+          preferences: request.preferences,
+          additionalInfo: request.additional_info || {}
+        }
+      })
+      expect(result.tracking_code).toBe(sharedCode)
+      expect(result.id).toBe('42')
+      expect(result.submitted_at).toBe(submittedAt.toISOString())
+    } finally {
+      generateSpy.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- extract the tracking code generator into `server/utils/tracking.ts`
- reuse the shared helper in `ApplicationRepository` and the API helpers while fixing the tracking comment
- add repository and helper tests covering tracking code generation

## Testing
- npm test -- --run *(fails: existing component/composable tests require Vue globals such as `readonly` and icon mocks)*
- npx vitest run tests/server/tracking.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68cbeb6cf0f08333acc8db7c3c6eb0f6