### PR TITLE
Refine directions repository pagination and API

### DIFF
--- a/server/api/v1/directions/index.get.ts
+++ b/server/api/v1/directions/index.get.ts
@@ -10,21 +10,19 @@ export default defineEventHandler(async (event): Promise<DirectionResponse> => {
 
     const page = Math.max(1, Number(query.page) || 1)
     const limit = Math.max(1, Math.min(1000, Number(query.limit) || 100))
-    const q = (query.q || '').toString().trim().toLowerCase()
+    const search = (query.q || '').toString().trim()
+    const searchTerm = search.length > 0 ? search : undefined
 
     const repo = new UniversityRepository(prisma)
-    const all = await repo.getAllDirections(query.lang || locale)
-
-    const filtered = q
-      ? all.filter(d => (d.name || '').toLowerCase().includes(q))
-      : all
-
-    const start = (page - 1) * limit
-    const data = filtered.slice(start, start + limit)
+    const { data, total } = await repo.getAllDirections(query.lang || locale, {
+      search: searchTerm,
+      page,
+      limit
+    })
 
     return {
       data,
-      meta: calculatePagination(filtered.length, page, limit)
+      meta: calculatePagination(total, page, limit)
     }
   } catch (error) {
     console.error('Error fetching directions:', error)

--- a/tests/server/api/directions/index.get.spec.ts
+++ b/tests/server/api/directions/index.get.spec.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+declare global {
+  // eslint-disable-next-line no-var
+  var defineEventHandler: <T>(handler: T) => T
+  // eslint-disable-next-line no-var
+  var getQuery: (event: any) => Record<string, any>
+  // eslint-disable-next-line no-var
+  var createError: (input: any) => any
+}
+
+const getQueryMock = vi.fn()
+const repoInstance = { getAllDirections: vi.fn() }
+const UniversityRepositoryMock = vi.fn(() => repoInstance)
+
+beforeEach(() => {
+  getQueryMock.mockReset()
+  repoInstance.getAllDirections.mockReset()
+  UniversityRepositoryMock.mockClear()
+})
+
+globalThis.defineEventHandler = (<T>(handler: T) => handler) as any
+globalThis.getQuery = getQueryMock as any
+globalThis.createError = (input: any) => input
+
+vi.mock('../../../../lib/prisma', () => ({
+  prisma: {}
+}))
+
+vi.mock('../../../../server/repositories', () => ({
+  UniversityRepository: UniversityRepositoryMock
+}))
+
+describe('GET /api/v1/directions', () => {
+  it('returns paginated directions with metadata from repository', async () => {
+    getQueryMock.mockReturnValue({ q: 'search term', page: '2', limit: '5', lang: 'en' })
+
+    const repoResponse = {
+      data: [
+        { id: 1, name: 'Direction 1', description: 'Desc 1', slug: 'direction-1', universities_count: 3 },
+        { id: 2, name: 'Direction 2', description: 'Desc 2', slug: 'direction-2', universities_count: 5 }
+      ],
+      total: 42
+    }
+
+    repoInstance.getAllDirections.mockResolvedValue(repoResponse)
+
+    const handlerModule = await import('../../../../server/api/v1/directions/index.get')
+    const handler = handlerModule.default
+
+    const event = { context: { locale: 'ru' } }
+    const result = await handler(event as any)
+
+    expect(UniversityRepositoryMock).toHaveBeenCalledWith(expect.any(Object))
+    expect(repoInstance.getAllDirections).toHaveBeenCalledWith('en', {
+      search: 'search term',
+      page: 2,
+      limit: 5
+    })
+
+    expect(result).toEqual({
+      data: repoResponse.data,
+      meta: {
+        total: 42,
+        page: 2,
+        limit: 5,
+        totalPages: 9
+      }
+    })
+  })
+
+  it('falls back to locale context values when query params missing', async () => {
+    getQueryMock.mockReturnValue({})
+
+    const repoResponse = {
+      data: [],
+      total: 0
+    }
+
+    repoInstance.getAllDirections.mockResolvedValue(repoResponse)
+
+    const handlerModule = await import('../../../../server/api/v1/directions/index.get')
+    const handler = handlerModule.default
+
+    const event = { context: { locale: 'tr' } }
+    const result = await handler(event as any)
+
+    expect(repoInstance.getAllDirections).toHaveBeenCalledWith('tr', {
+      search: undefined,
+      page: 1,
+      limit: 100
+    })
+
+    expect(result.meta).toEqual({
+      total: 0,
+      page: 1,
+      limit: 100,
+      totalPages: 1
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- refactor `UniversityRepository.getAllDirections` to use typed Prisma queries with locale scoped translations, filtering, pagination, and counts
- update the directions API endpoint to call the paginated repository method and return database-derived pagination metadata
- add unit tests covering the endpoint’s interaction with the repository and pagination defaults

## Testing
- npx vitest run tests/server/api/directions/index.get.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cbeb6c35f08333a447c25422c1355b