### PR TITLE
Refactor university repository filter aggregation

### DIFF
--- a/app/stores/universities.ts
+++ b/app/stores/universities.ts
@@ -12,6 +12,7 @@ export const useUniversitiesStore = defineStore('universities', () => {
     cities: [],
     types: [],
     levels: [],
+    languages: [],
     priceRange: [0, 20000]
   })
   

--- a/server/repositories/UniversityRepository.ts
+++ b/server/repositories/UniversityRepository.ts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { PrismaClient } from '@prisma/client'
+import type { Prisma, PrismaClient } from '@prisma/client'
 import type { DegreeType, UniversityType } from '../../app/types/domain'
 import type { University, UniversityQueryParams, UniversityDetail } from '../types/api'
 
@@ -49,6 +48,7 @@ export class UniversityRepository {
       cities: string[]
       types: string[]
       levels: string[]
+      languages: string[]
       priceRange: [number, number]
     }
   }> {
@@ -66,7 +66,7 @@ export class UniversityRepository {
     } = params
 
     // Build where clause
-    const where: any = {}
+    const where: Prisma.UniversityWhereInput = {}
 
     // Price filter based on normalized fields
     if (price_min !== undefined || price_max !== undefined) {
@@ -184,7 +184,7 @@ export class UniversityRepository {
     }
 
     // Build order by clause
-    let orderBy: any = { id: 'asc' } // default
+    let orderBy: Prisma.UniversityOrderByWithRelationInput = { id: 'asc' }
 
     switch (sort) {
       case 'price_asc':
@@ -222,77 +222,50 @@ export class UniversityRepository {
       this.prisma.university.count({ where })
     ])
 
-    // Get filter options
-    const [allUniversities] = await this.prisma.$transaction([
-      this.prisma.university.findMany({
-        include: {
-          city: { include: { translations: true } },
-          translations: true,
-          academicPrograms: true
-        }
-      })
-    ])
+    const filters = await this.buildFilterOptions(locale)
 
-    // Extract cities with fallback logic
-    const availableCities = [...new Set(
-      allUniversities
-        .map(u => {
-          const ct = (u.city?.translations || []) as Array<{ locale: string; name: string }>
-          const best = this.selectBestTranslation(ct, locale)
-          return best?.name
-        })
-        .filter(Boolean)
-    )].sort()
+    type UniversityListItem = Prisma.UniversityGetPayload<{
+      include: {
+        translations: true
+        academicPrograms: true
+        city: { include: { translations: true } }
+      }
+    }>
 
-    const availableTypes = ['state', 'private', 'tech', 'elite']
-    const availableLevels = ['bachelor', 'master', 'phd']
-    const allAny = allUniversities as any[]
-    const priceCandidates: number[] = allAny.map(u => Number(u.tuitionMin || u.tuitionMax || 0)).filter(v => !Number.isNaN(v))
-    const priceRange: [number, number] = [
-      priceCandidates.length ? Math.min(...priceCandidates) : 0,
-      priceCandidates.length ? Math.max(...priceCandidates) : 50000
-    ]
-
-    // Transform to API format with normalized structure
-    const transformedUniversities: University[] = (universities as any[]).map((uni: any) => {
+    const transformedUniversities: University[] = (universities as UniversityListItem[]).map(uni => {
       const translation = this.selectBestTranslation(uni.translations, locale)
-      const languageCodes = (uni.academicPrograms || []).map((p: any) => p.languageCode).filter(Boolean)
-      const cityTr = this.selectBestTranslation((uni.city?.translations || []) as any[], locale)
+      const languageCodes = uni.academicPrograms.map(program => program.languageCode)
+      const cityTranslation = uni.city?.translations
+        ? this.selectBestTranslation(uni.city.translations, locale)
+        : null
+      const keyInfoTexts = this.asRecord(translation?.keyInfoTexts)
 
       return {
         id: uni.id,
-        title: (translation as any)?.title || '',
-        description: (translation as any)?.description || '',
-        city: (cityTr as any)?.name || '',
-        foundedYear: uni.foundedYear || 0,
+        title: translation?.title ?? '',
+        description: translation?.description ?? '',
+        city: cityTranslation?.name ?? '',
+        foundedYear: uni.foundedYear ?? 0,
         type: uni.type as UniversityType,
-        
-        // Нормализованная стоимость
         tuitionRange: {
-          min: Number(uni.tuitionMin || 0),
-          max: Number(uni.tuitionMax || 0),
-          currency: uni.currency || 'USD'
+          min: this.decimalToNumber(uni.tuitionMin),
+          max: this.decimalToNumber(uni.tuitionMax),
+          currency: uni.currency ?? 'USD'
         },
-        
-        // Нормализованные данные о студентах  
-        totalStudents: uni.totalStudents || 0,
-        internationalStudents: uni.internationalStudents || 0,
-        
-        // Нормализованный рейтинг (только текст из keyInfoTexts если есть)
+        totalStudents: uni.totalStudents ?? 0,
+        internationalStudents: uni.internationalStudents ?? 0,
         ranking: {
-          text: (translation as any)?.keyInfoTexts?.ranking_text || undefined
+          text: typeof keyInfoTexts?.ranking_text === 'string' ? keyInfoTexts.ranking_text : undefined
         },
-        
-        // Нормализованное проживание
-        hasAccommodation: uni.hasAccommodation || false,
-        
-        // Мета данные
-        languages: Array.from(new Set(languageCodes)),
-        slug: this.getSlugForLocaleFromTranslations(uni.translations as any[], locale),
-        image: uni.image || '',
-        heroImage: uni.heroImage || uni.image,
-        // Use lite badge that doesn't rely on unloaded relations
-        badge: this.generateBadgeLite(uni, locale)
+        hasAccommodation: uni.hasAccommodation ?? false,
+        languages: Array.from(new Set(languageCodes.filter(Boolean))),
+        slug: this.getSlugForLocaleFromTranslations(
+          uni.translations.map(({ locale: trLocale, slug }) => ({ locale: trLocale, slug })),
+          locale
+        ),
+        image: uni.image ?? '',
+        heroImage: uni.heroImage ?? uni.image ?? '',
+        badge: this.generateBadgeLite({ type: uni.type }, locale)
       }
     })
 
@@ -312,12 +285,101 @@ export class UniversityRepository {
     return {
       data: prioritized,
       total,
-      filters: {
-        cities: availableCities,
-        types: availableTypes,
-        levels: availableLevels,
-        priceRange
-      }
+      filters
+    }
+  }
+
+  private decimalToNumber(value: Prisma.Decimal | number | null | undefined): number {
+    if (value == null) return 0
+    return typeof value === 'number' ? value : Number(value)
+  }
+
+  private asRecord(value: Prisma.JsonValue | null | undefined): Record<string, any> | null {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return value as Record<string, any>
+    }
+    return null
+  }
+
+  private async buildFilterOptions(locale: string): Promise<{
+    cities: string[]
+    types: string[]
+    levels: string[]
+    languages: string[]
+    priceRange: [number, number]
+  }> {
+    const [cityGroups, typeGroups, levelGroups, tuitionAggregates, languageGroups] = await Promise.all([
+      this.prisma.university.groupBy({
+        by: ['cityId'],
+        where: { cityId: { not: null } }
+      }),
+      this.prisma.university.groupBy({
+        by: ['type']
+      }),
+      this.prisma.academicProgram.groupBy({
+        by: ['degreeType']
+      }),
+      this.prisma.university.aggregate({
+        _min: { tuitionMin: true, tuitionMax: true },
+        _max: { tuitionMin: true, tuitionMax: true }
+      }),
+      this.prisma.academicProgram.groupBy({
+        by: ['languageCode']
+      })
+    ])
+
+    const cityIds = cityGroups
+      .map(group => group.cityId)
+      .filter((value): value is number => value !== null && value !== undefined)
+
+    const cityTranslations = cityIds.length
+      ? await this.prisma.cityTranslation.findMany({
+          where: {
+            cityId: { in: cityIds },
+            locale: { in: [locale, 'ru'] }
+          },
+          select: { cityId: true, locale: true, name: true }
+        })
+      : []
+
+    const cityNames = cityIds
+      .map(id => {
+        const translations = cityTranslations.filter(t => t.cityId === id)
+        const best = this.selectBestTranslation(translations, locale)
+        return best?.name
+      })
+      .filter((name): name is string => Boolean(name))
+
+    const availableCities = Array.from(new Set(cityNames)).sort((a, b) => a.localeCompare(b))
+    const availableTypes = typeGroups
+      .map(group => group.type)
+      .filter((type): type is UniversityType => Boolean(type))
+      .sort((a, b) => a.localeCompare(b))
+    const availableLevels = levelGroups
+      .map(group => group.degreeType)
+      .filter((level): level is DegreeType => Boolean(level))
+      .sort((a, b) => a.localeCompare(b))
+    const availableLanguages = languageGroups
+      .map(group => group.languageCode)
+      .filter((code): code is string => Boolean(code))
+      .sort((a, b) => a.localeCompare(b))
+
+    const minCandidates = [tuitionAggregates._min.tuitionMin, tuitionAggregates._min.tuitionMax]
+      .filter((value): value is Prisma.Decimal => value !== null)
+      .map(value => Number(value))
+    const maxCandidates = [tuitionAggregates._max.tuitionMin, tuitionAggregates._max.tuitionMax]
+      .filter((value): value is Prisma.Decimal => value !== null)
+      .map(value => Number(value))
+
+    const minPrice = minCandidates.length > 0 ? Math.min(...minCandidates) : 0
+    const maxPrice = maxCandidates.length > 0 ? Math.max(...maxCandidates) : 50000
+
+    return {
+      cities: availableCities,
+      types: availableTypes,
+      levels: availableLevels,
+      languages: availableLanguages,
+      priceRange: [minPrice, maxPrice]
     }
   }
 

--- a/server/types/api.ts
+++ b/server/types/api.ts
@@ -223,6 +223,7 @@ export interface UniversityFilters {
   cities: string[]
   types: string[]
   levels: string[]
+  languages: string[]
   priceRange: [number, number]
 }
 

--- a/tests/server/UniversityRepository.spec.ts
+++ b/tests/server/UniversityRepository.spec.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PrismaClient } from '@prisma/client'
+import { Prisma } from '@prisma/client'
+
+import { UniversityRepository } from '../../server/repositories/UniversityRepository'
+import type { UniversityQueryParams } from '../../server/types/api'
+
+type UniversityListItem = Prisma.UniversityGetPayload<{
+  include: {
+    translations: true
+    academicPrograms: true
+    city: { include: { translations: true } }
+  }
+}>
+
+describe('UniversityRepository.findAll', () => {
+  it('builds filters using aggregate queries and returns transformed data', async () => {
+    const baseDate = new Date('2024-01-01T00:00:00.000Z')
+
+    const universities: UniversityListItem[] = [
+      {
+        id: 1,
+        countryId: null,
+        cityId: 10,
+        foundedYear: 1950,
+        type: 'tech',
+        tuitionMin: new Prisma.Decimal(1500),
+        tuitionMax: new Prisma.Decimal(5500),
+        currency: 'USD',
+        totalStudents: 12000,
+        internationalStudents: 1500,
+        rankingScore: null,
+        hasAccommodation: true,
+        hasScholarships: false,
+        heroImage: null,
+        image: 'tech-uni.jpg',
+        createdAt: baseDate,
+        updatedAt: baseDate,
+        translations: [
+          {
+            id: 11,
+            universityId: 1,
+            locale: 'en',
+            title: 'Tech University',
+            description: 'Leading technology university',
+            slug: 'tech-university',
+            about: null,
+            strongPrograms: null,
+            keyInfoTexts: { ranking_text: 'Top 100 globally' },
+            createdAt: baseDate,
+            updatedAt: baseDate
+          },
+          {
+            id: 12,
+            universityId: 1,
+            locale: 'ru',
+            title: 'Технический университет',
+            description: 'Ведущий технический университет',
+            slug: 'tekhnicheskiy-universitet',
+            about: null,
+            strongPrograms: null,
+            keyInfoTexts: { ranking_text: 'Топ-100 в мире' },
+            createdAt: baseDate,
+            updatedAt: baseDate
+          }
+        ],
+        academicPrograms: [
+          {
+            id: 21,
+            universityId: 1,
+            degreeType: 'bachelor',
+            languageCode: 'EN',
+            durationYears: 4,
+            tuitionPerYear: new Prisma.Decimal(5000),
+            createdAt: baseDate,
+            updatedAt: baseDate
+          },
+          {
+            id: 22,
+            universityId: 1,
+            degreeType: 'master',
+            languageCode: 'TR',
+            durationYears: 2,
+            tuitionPerYear: new Prisma.Decimal(6000),
+            createdAt: baseDate,
+            updatedAt: baseDate
+          }
+        ],
+        city: {
+          id: 10,
+          countryId: 1,
+          createdAt: baseDate,
+          updatedAt: baseDate,
+          translations: [
+            { id: 31, cityId: 10, locale: 'en', name: 'Ankara', createdAt: baseDate, updatedAt: baseDate },
+            { id: 32, cityId: 10, locale: 'ru', name: 'Анкара', createdAt: baseDate, updatedAt: baseDate }
+          ]
+        }
+      }
+    ]
+
+    const findMany = vi.fn().mockResolvedValue(universities)
+    const count = vi.fn().mockResolvedValue(universities.length)
+    const universityGroupBy = vi.fn().mockImplementation((args: Prisma.UniversityGroupByArgs) => {
+      if ('by' in args && Array.isArray(args.by) && args.by.includes('cityId')) {
+        return Promise.resolve([{ cityId: 10 }])
+      }
+      if ('by' in args && Array.isArray(args.by) && args.by.includes('type')) {
+        return Promise.resolve([{ type: 'tech' }, { type: 'state' }])
+      }
+      return Promise.resolve([])
+    })
+    const aggregate = vi.fn().mockResolvedValue({
+      _min: { tuitionMin: new Prisma.Decimal(1000), tuitionMax: new Prisma.Decimal(1200) },
+      _max: { tuitionMin: new Prisma.Decimal(7000), tuitionMax: new Prisma.Decimal(8200) }
+    })
+    const academicProgramGroupBy = vi.fn().mockImplementation((args: Prisma.AcademicProgramGroupByArgs) => {
+      if ('by' in args && Array.isArray(args.by) && args.by.includes('degreeType')) {
+        return Promise.resolve([{ degreeType: 'bachelor' }, { degreeType: 'master' }])
+      }
+      if ('by' in args && Array.isArray(args.by) && args.by.includes('languageCode')) {
+        return Promise.resolve([{ languageCode: 'EN' }, { languageCode: 'TR' }])
+      }
+      return Promise.resolve([])
+    })
+    const cityTranslationFindMany = vi.fn().mockResolvedValue([
+      { cityId: 10, locale: 'en', name: 'Ankara' },
+      { cityId: 10, locale: 'ru', name: 'Анкара' }
+    ])
+    const transaction = vi.fn(async (queries: Promise<unknown>[]) => Promise.all(queries))
+
+    const prisma = {
+      university: {
+        findMany,
+        count,
+        groupBy: universityGroupBy,
+        aggregate
+      },
+      academicProgram: {
+        groupBy: academicProgramGroupBy
+      },
+      cityTranslation: {
+        findMany: cityTranslationFindMany
+      },
+      $transaction: transaction
+    } as unknown as PrismaClient
+
+    const repository = new UniversityRepository(prisma)
+    const params: UniversityQueryParams = { page: 1, limit: 12 }
+
+    const result = await repository.findAll(params, 'en')
+
+    expect(transaction).toHaveBeenCalledTimes(1)
+    expect(findMany).toHaveBeenCalledTimes(1)
+    expect(count).toHaveBeenCalledTimes(1)
+
+    expect(universityGroupBy).toHaveBeenCalledTimes(2)
+    expect(academicProgramGroupBy).toHaveBeenCalledTimes(2)
+    expect(cityTranslationFindMany).toHaveBeenCalledWith({
+      where: { cityId: { in: [10] }, locale: { in: ['en', 'ru'] } },
+      select: { cityId: true, locale: true, name: true }
+    })
+
+    expect(result.filters).toEqual({
+      cities: ['Ankara'],
+      types: ['state', 'tech'],
+      levels: ['bachelor', 'master'],
+      languages: ['EN', 'TR'],
+      priceRange: [1000, 8200]
+    })
+
+    expect(result.data).toHaveLength(1)
+    const university = result.data[0]
+    expect(university.title).toBe('Tech University')
+    expect(university.city).toBe('Ankara')
+    expect(university.tuitionRange).toEqual({ min: 1500, max: 5500, currency: 'USD' })
+    expect(university.languages).toEqual(['EN', 'TR'])
+    expect(university.ranking?.text).toBe('Top 100 globally')
+    expect(university.heroImage).toBe('tech-uni.jpg')
+    expect(university.slug).toBe('tech-university')
+    expect(university.badge).toEqual({
+      labelKey: 'universities_page.card.badges.technical',
+      color: 'purple'
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- replace the university repository filter metadata queries with typed Prisma where/order inputs and aggregation-driven lookups, including available languages
- adjust the list transformation to use proper Prisma payload typings and helper utilities for JSON/decimal handling
- extend the shared filters contract and store defaults with languages and add a regression spec covering the aggregation pipeline

## Testing
- npx tsc --noEmit
- npx vitest run tests/server/UniversityRepository.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cbeb68dc4c8333bcf17c2366522b39