### PR TITLE
feat: add messenger channel tracking

### DIFF
--- a/app/composables/useContactChannels.ts
+++ b/app/composables/useContactChannels.ts
@@ -1,0 +1,101 @@
+import { computed } from 'vue'
+import { withQuery } from 'ufo'
+import { contactChannels, personalTelegramChannelKey, type ContactChannelDefinition, type ContactChannelKey } from '~/lib/contact/channels'
+import { useReferral } from './useReferral'
+
+export interface ContactChannelInstance extends ContactChannelDefinition {
+  href: string
+  cta: string
+  message?: string
+}
+
+const REFERRAL_PLACEHOLDER = /\{\{\s*referral\s*\}\}/gi
+
+const sanitizeMessage = (template: string | undefined, referral: string): string | undefined => {
+  if (!template) {
+    return undefined
+  }
+
+  const replaced = template.replace(REFERRAL_PLACEHOLDER, referral || '').trim()
+  return replaced.length > 0 ? replaced : undefined
+}
+
+const buildGoTelegramHref = (
+  referral: string,
+  sessionId: string | undefined,
+  utm: Record<string, string>
+): string => {
+  const query: Record<string, string> = {}
+
+  if (referral) {
+    query.referral_code = referral
+  }
+
+  if (sessionId) {
+    query.session = sessionId
+  }
+
+  for (const [key, value] of Object.entries(utm)) {
+    if (value) {
+      query[key] = value
+    }
+  }
+
+  return Object.keys(query).length > 0 ? withQuery('/go/telegram', query) : '/go/telegram'
+}
+
+const extractUtmParams = (query: Record<string, any>): Record<string, string> => {
+  return Object.entries(query).reduce<Record<string, string>>((acc, [key, value]) => {
+    if (key.startsWith('utm_') && typeof value === 'string' && value.length > 0) {
+      acc[key] = value
+    }
+    return acc
+  }, {})
+}
+
+export const useContactChannels = () => {
+  const { referralCode } = useReferral()
+  const route = useRoute()
+
+  const channels = computed<Record<ContactChannelKey, ContactChannelInstance>>(() => {
+    const referral = referralCode.value || ''
+    const sessionId = typeof route.query.session === 'string' ? route.query.session : undefined
+    const utmParams = extractUtmParams(route.query as Record<string, any>)
+
+    return Object.entries(contactChannels).reduce<Record<ContactChannelKey, ContactChannelInstance>>(
+      (acc, [key, definition]) => {
+        const typedKey = key as ContactChannelKey
+        const message = sanitizeMessage(definition.defaultMessage, referral)
+        let href = definition.baseUrl
+
+        if (typedKey === personalTelegramChannelKey) {
+          href = buildGoTelegramHref(referral, sessionId, utmParams)
+        } else if (definition.queryParam && message) {
+          href = withQuery(definition.baseUrl, { [definition.queryParam]: message })
+        } else if (typedKey === 'telegramBot' && referral) {
+          href = withQuery(definition.baseUrl, { start: referral })
+        }
+
+        acc[typedKey] = {
+          ...definition,
+          href,
+          cta: definition.defaultCta,
+          message
+        }
+
+        return acc
+      },
+      {} as Record<ContactChannelKey, ContactChannelInstance>
+    )
+  })
+
+  const channelList = computed(() => Object.values(channels.value))
+
+  const getChannel = (key: ContactChannelKey) => computed(() => channels.value[key])
+
+  return {
+    channels,
+    channelList,
+    getChannel
+  }
+}

--- a/lib/contact/channels.ts
+++ b/lib/contact/channels.ts
@@ -1,0 +1,52 @@
+export type ContactChannelType = 'bot' | 'personal' | 'social'
+
+export interface ContactChannelDefinition {
+  key: ContactChannelKey
+  type: ContactChannelType
+  baseUrl: string
+  defaultCta: string
+  defaultMessage?: string
+  queryParam?: string
+  copyOnNavigate?: boolean
+}
+
+export type ContactChannelKey =
+  | 'telegramPersonal'
+  | 'telegramBot'
+  | 'whatsapp'
+  | 'instagram'
+
+export const contactChannels: Record<ContactChannelKey, ContactChannelDefinition> = {
+  telegramPersonal: {
+    key: 'telegramPersonal',
+    type: 'personal',
+    baseUrl: 'https://t.me/eduturkish',
+    defaultCta: 'Связаться с консультантом',
+    defaultMessage: 'Здравствуйте! Меня направил партнёр с кодом {{referral}}. Хочу получить консультацию по обучению в Турции.',
+    copyOnNavigate: true
+  },
+  telegramBot: {
+    key: 'telegramBot',
+    type: 'bot',
+    baseUrl: 'https://t.me/eduturkish_bot',
+    defaultCta: 'Запустить Telegram-бота',
+    defaultMessage: '{{referral}}',
+    queryParam: 'start'
+  },
+  whatsapp: {
+    key: 'whatsapp',
+    type: 'personal',
+    baseUrl: 'https://wa.me/905438679950',
+    defaultCta: 'Написать в WhatsApp',
+    defaultMessage: 'Здравствуйте! Меня направил партнёр с кодом {{referral}}. Подскажите, пожалуйста, по обучению в Турции.',
+    queryParam: 'text'
+  },
+  instagram: {
+    key: 'instagram',
+    type: 'social',
+    baseUrl: 'https://www.instagram.com/edu.turkish/',
+    defaultCta: 'Подписаться в Instagram'
+  }
+}
+
+export const personalTelegramChannelKey: ContactChannelKey = 'telegramPersonal'

--- a/server/api/v1/messenger-events.post.ts
+++ b/server/api/v1/messenger-events.post.ts
@@ -1,0 +1,64 @@
+import { BitrixService } from '../../services/BitrixService'
+import { getBitrixConfig } from '../../utils/bitrix-config'
+
+interface MessengerEventRequestBody {
+  channel?: string
+  referral_code?: string
+  session?: string
+  utm?: Record<string, unknown>
+  metadata?: Record<string, unknown>
+}
+
+const sanitizeUtmPayload = (utm: MessengerEventRequestBody['utm']): Record<string, string> => {
+  if (!utm || typeof utm !== 'object') {
+    return {}
+  }
+
+  return Object.entries(utm).reduce<Record<string, string>>((acc, [key, value]) => {
+    if (typeof value === 'string' && value.length > 0) {
+      acc[key] = value
+    }
+    return acc
+  }, {})
+}
+
+export default defineEventHandler(async event => {
+  const body = await readBody<MessengerEventRequestBody>(event)
+  const channel = body.channel?.trim()
+  const referralCode = body.referral_code?.trim()
+
+  if (!channel) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Channel is required'
+    })
+  }
+
+  if (!referralCode) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Referral code is required'
+    })
+  }
+
+  const bitrixService = new BitrixService(getBitrixConfig())
+  const result = await bitrixService.logMessengerEvent({
+    channel,
+    referralCode,
+    session: typeof body.session === 'string' && body.session.length > 0 ? body.session : undefined,
+    utm: sanitizeUtmPayload(body.utm),
+    metadata: typeof body.metadata === 'object' && body.metadata ? body.metadata : undefined
+  })
+
+  if (!result.success) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: result.error || 'Failed to log messenger event'
+    })
+  }
+
+  return {
+    success: true,
+    activityId: result.activityId ?? null
+  }
+})

--- a/server/routes/go/telegram.ts
+++ b/server/routes/go/telegram.ts
@@ -1,0 +1,106 @@
+import { getRequestURL } from 'h3'
+import { contactChannels, personalTelegramChannelKey } from '~/lib/contact/channels'
+
+const REFERRAL_PLACEHOLDER = /\{\{\s*referral\s*\}\}/gi
+
+const extractUtmParams = (query: Record<string, any>): Record<string, string> => {
+  return Object.entries(query).reduce<Record<string, string>>((acc, [key, value]) => {
+    if (key.startsWith('utm_') && typeof value === 'string' && value.length > 0) {
+      acc[key] = value
+    }
+    return acc
+  }, {})
+}
+
+const buildGreeting = (template: string | undefined, referral: string): string | undefined => {
+  if (!template) {
+    return undefined
+  }
+
+  const text = template.replace(REFERRAL_PLACEHOLDER, referral || '').trim()
+  return text.length > 0 ? text : undefined
+}
+
+export default defineEventHandler(async event => {
+  const query = getQuery(event)
+  const referralCode = typeof query.referral_code === 'string' ? query.referral_code : ''
+
+  if (!referralCode) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Referral code is required'
+    })
+  }
+
+  const sessionId = typeof query.session === 'string' && query.session.length > 0 ? query.session : undefined
+  const utmParams = extractUtmParams(query as Record<string, any>)
+
+  const requestUrl = getRequestURL(event)
+  await $fetch('/api/v1/messenger-events', {
+    method: 'POST',
+    body: {
+      channel: personalTelegramChannelKey,
+      referral_code: referralCode,
+      session: sessionId,
+      utm: utmParams
+    },
+    baseURL: requestUrl.origin
+  })
+
+  const channelConfig = contactChannels[personalTelegramChannelKey]
+  const greetingText = buildGreeting(channelConfig.defaultMessage, referralCode)
+  const shouldCopy = Boolean(channelConfig.copyOnNavigate && greetingText)
+
+  const html = `<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <title>Переходим в Telegram...</title>
+  </head>
+  <body>
+    <script>
+      const targetUrl = ${JSON.stringify(channelConfig.baseUrl)}
+      const greeting = ${JSON.stringify(greetingText || '')}
+      const shouldCopy = ${JSON.stringify(shouldCopy)}
+
+      ;(async () => {
+        const redirect = () => {
+          window.location.replace(targetUrl)
+        }
+
+        if (!shouldCopy) {
+          redirect()
+          return
+        }
+
+        try {
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            await navigator.clipboard.writeText(greeting)
+          } else {
+            const textarea = document.createElement('textarea')
+            textarea.value = greeting
+            textarea.setAttribute('readonly', '')
+            textarea.style.position = 'absolute'
+            textarea.style.left = '-9999px'
+            document.body.appendChild(textarea)
+            textarea.select()
+            document.execCommand('copy')
+            document.body.removeChild(textarea)
+          }
+        } catch (error) {
+          console.warn('Failed to copy greeting text', error)
+        } finally {
+          redirect()
+        }
+      })()
+    </script>
+    <p>Перенаправляем вас в Telegram...</p>
+  </body>
+</html>`
+
+  return new Response(html, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8'
+    }
+  })
+})

--- a/tests/server/api/v1/messenger-events.post.spec.ts
+++ b/tests/server/api/v1/messenger-events.post.spec.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+declare global {
+  // eslint-disable-next-line no-var
+  var defineEventHandler: <T>(handler: T) => T
+  // eslint-disable-next-line no-var
+  var readBody: <T>(event: any) => Promise<T>
+  // eslint-disable-next-line no-var
+  var createError: (input: any) => any
+}
+
+const readBodyMock = vi.fn()
+const logMessengerEventMock = vi.fn()
+const BitrixServiceMock = vi.fn(() => ({
+  logMessengerEvent: logMessengerEventMock
+}))
+const getBitrixConfigMock = vi.fn(() => ({ domain: 'example.com', accessToken: 'token' }))
+
+vi.mock('../../../../server/services/BitrixService', () => ({
+  BitrixService: BitrixServiceMock
+}))
+
+vi.mock('../../../../server/utils/bitrix-config', () => ({
+  getBitrixConfig: getBitrixConfigMock
+}))
+
+beforeEach(() => {
+  readBodyMock.mockReset()
+  logMessengerEventMock.mockReset()
+  BitrixServiceMock.mockClear()
+  getBitrixConfigMock.mockClear()
+})
+
+globalThis.defineEventHandler = (<T>(handler: T) => handler) as any
+; (globalThis as any).readBody = readBodyMock
+; (globalThis as any).createError = (input: any) => input
+
+describe('POST /api/v1/messenger-events', () => {
+  it('requires referral code to be provided', async () => {
+    readBodyMock.mockResolvedValue({ channel: 'telegramPersonal' })
+
+    const handlerModule = await import('../../../../server/api/v1/messenger-events.post')
+    const handler = handlerModule.default
+
+    await expect(handler({} as any)).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: 'Referral code is required'
+    })
+
+    expect(BitrixServiceMock).not.toHaveBeenCalled()
+  })
+
+  it('proxies payload to Bitrix service when valid', async () => {
+    readBodyMock.mockResolvedValue({
+      channel: 'telegramPersonal',
+      referral_code: 'ref-123',
+      session: 'session-1',
+      utm: {
+        utm_source: 'test-source',
+        utm_medium: '',
+        other: 42
+      },
+      metadata: {
+        page: '/contacts'
+      }
+    })
+
+    logMessengerEventMock.mockResolvedValue({ success: true, activityId: 99 })
+
+    const handlerModule = await import('../../../../server/api/v1/messenger-events.post')
+    const handler = handlerModule.default
+
+    const result = await handler({} as any)
+
+    expect(BitrixServiceMock).toHaveBeenCalledWith({ domain: 'example.com', accessToken: 'token' })
+    expect(logMessengerEventMock).toHaveBeenCalledWith({
+      channel: 'telegramPersonal',
+      referralCode: 'ref-123',
+      session: 'session-1',
+      utm: {
+        utm_source: 'test-source'
+      },
+      metadata: {
+        page: '/contacts'
+      }
+    })
+    expect(result).toEqual({
+      success: true,
+      activityId: 99
+    })
+  })
+
+  it('returns 502 when Bitrix logging fails', async () => {
+    readBodyMock.mockResolvedValue({
+      channel: 'telegramPersonal',
+      referral_code: 'ref-123'
+    })
+
+    logMessengerEventMock.mockResolvedValue({ success: false, error: 'Failed to log' })
+
+    const handlerModule = await import('../../../../server/api/v1/messenger-events.post')
+    const handler = handlerModule.default
+
+    await expect(handler({} as any)).rejects.toMatchObject({
+      statusCode: 502,
+      statusMessage: 'Failed to log'
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- добавил конфигурацию контактных каналов и композицию useContactChannels для подготовки ссылок с реферальным кодом
- реализовал API /api/v1/messenger-events, обновил BitrixService и серверный редирект /go/telegram с логированием переходов
- написал юнит-тесты, проверяющие обязательность referral и проксирование данных в Bitrix

## Testing
- npx vitest run --run tests/server/api/v1/messenger-events.post.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc22545c148333bb8ebf3975ded936