### PR TITLE
Make blog sidebar popular list dynamic

### DIFF
--- a/app/stores/blog.ts
+++ b/app/stores/blog.ts
@@ -4,6 +4,7 @@ import type {
   BlogArticleListItem,
   BlogArticlesResponse,
   BlogCategory,
+  BlogPopularArticle,
   PaginationMeta
 } from '../../server/types/api'
 
@@ -18,6 +19,7 @@ export const useBlogStore = defineStore('blog', () => {
   const articles = ref<BlogArticleListItem[]>([])
   const featuredArticle = ref<BlogArticleListItem | null>(null)
   const categories = ref<BlogCategory[]>([])
+  const popular = ref<BlogPopularArticle[]>([])
   const pagination = ref<PaginationMeta | null>(null)
   const loading = ref(false)
   const error = ref<string | null>(null)
@@ -86,6 +88,7 @@ export const useBlogStore = defineStore('blog', () => {
 
       pagination.value = response.meta ?? null
       categories.value = response.categories ?? []
+      popular.value = response.popular ?? []
 
       if (!append) {
         articles.value = response.data
@@ -152,6 +155,7 @@ export const useBlogStore = defineStore('blog', () => {
     articles,
     featuredArticle,
     categories,
+    popular,
     pagination,
     loading,
     error,

--- a/server/api/v1/blog/articles/index.get.ts
+++ b/server/api/v1/blog/articles/index.get.ts
@@ -20,7 +20,8 @@ export default defineEventHandler(async (event): Promise<BlogArticlesResponse> =
       data: result.articles,
       meta: calculatePagination(result.total, page, limit),
       featured: result.featured,
-      categories: result.categories
+      categories: result.categories,
+      popular: result.popular
     }
   } catch (error) {
     console.error('Error fetching blog articles:', error)

--- a/server/types/api.ts
+++ b/server/types/api.ts
@@ -55,9 +55,20 @@ export interface BlogArticleDetail extends BlogArticleListItem {
   content: BlogArticleContentBlock[]
 }
 
+export interface BlogPopularArticle {
+  id: number
+  slug: string
+  title: string
+  publishedAt: string
+  publishedAtLabel: string
+  viewCount: number
+  viewCountLabel: string
+}
+
 export interface BlogArticlesResponse extends ApiResponse<BlogArticleListItem[]> {
   featured: BlogArticleListItem | null
   categories: BlogCategory[]
+  popular: BlogPopularArticle[]
 }
 
 export interface BlogArticleQueryParams {


### PR DESCRIPTION
## Summary
- extend the blog articles API to return a curated popular articles payload sourced from Prisma metadata
- expose the popular article list through the blog store and surface it in the blog page sidebar
- update the sidebar markup to link to article pages and gracefully fall back to static translations when no data is returned

## Testing
- `npm run lint` *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5a1de9848333bdc790c5bbd373ad