### PR TITLE
chore: remove unused facility and dormitory enums

### DIFF
--- a/app/assets/json/universities/types.ts
+++ b/app/assets/json/universities/types.ts
@@ -13,17 +13,6 @@ export type UniversityType = 'state' | 'private' | 'tech' | 'elite'
 export type DegreeType = 'bachelor' | 'master' | 'phd'
 export type ProgramLanguage = 'tr' | 'en'
 // DirectionSlug импортируется из централизованного файла
-// FacilityType в текущей БД не хранится на уровне сущности, оставлено для UI-подсказок
-export type FacilityType =
-  | 'academic'
-  | 'recreational'
-  | 'accommodation'
-  | 'dining'
-  | 'sports'
-  | 'medical'
-  | 'transport'
-  | 'technology'
-  | 'support'
 // Типы важной даты (ImportantDate.type)
 export type ImportantDateType = 'deadline' | 'event' | 'exam' | 'notification'
 
@@ -336,7 +325,6 @@ export interface UniversityJson {
 export const ALLOWED_UNIVERSITY_TYPES: UniversityType[] = ['state', 'private', 'tech', 'elite']
 export const ALLOWED_DEGREE_TYPES: DegreeType[] = ['bachelor', 'master', 'phd']
 export const ALLOWED_PROGRAM_LANGUAGES: ProgramLanguage[] = ['tr', 'en']
-export const ALLOWED_FACILITY_TYPES: FacilityType[] = ['academic', 'recreational', 'accommodation', 'technology', 'support']
 export const ALLOWED_IMPORTANT_DATE_TYPES: ImportantDateType[] = ['deadline', 'event', 'exam', 'notification']
 export { ALLOWED_DIRECTIONS }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -741,24 +741,6 @@ enum ApplicationStatus {
   rejected
 }
 
-enum FacilityType {
-  academic      // Академические (библиотека, лаборатории, аудитории)
-  recreational  // Развлекательные (спортзал, бассейн, клубы)
-  accommodation // Проживание (общежития)
-  dining       // Питание (столовые, кафе)
-  sports       // Спорт (стадионы, площадки)
-  medical      // Медицинские (медцентр, аптека)
-  transport    // Транспорт (парковки, автобусы)
-  technology   // Технологии (Wi-Fi, компьютерные классы)
-  support      // Поддержка (администрация, безопасность)
-}
-
-enum DormitoryType {
-  male
-  female
-  mixed
-}
-
 enum ScholarshipType {
   government
   university


### PR DESCRIPTION
## Summary
- remove the unused FacilityType and DormitoryType enums from the Prisma schema
- drop leftover FacilityType hints from the university JSON helper types

## Testing
- npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68cc5c6b880083338925044734ab5afe