### PR TITLE
Normalize university filters and cover price edge cases

### DIFF
--- a/server/api/v1/universities/index.get.ts
+++ b/server/api/v1/universities/index.get.ts
@@ -17,7 +17,7 @@ export default defineEventHandler(async (event): Promise<UniversityResponse> => 
     
     return {
       data: result.data,
-      meta: calculatePagination(result.total, filters.page, filters.limit),
+      meta: calculatePagination(result.total, filters.page ?? 1, filters.limit ?? 6),
       filters: result.filters
     }
   } catch (error) {

--- a/server/repositories/UniversityRepository.ts
+++ b/server/repositories/UniversityRepository.ts
@@ -60,27 +60,42 @@ export class UniversityRepository {
       langs = [],
       type,
       level,
-      price_min = 0,
-      price_max = 20000,
+      price_min,
+      price_max,
       sort = 'pop',
       page = 1,
-      limit = 12
+      limit = 6
     } = params
 
     // Build where clause
     const where: Prisma.UniversityWhereInput = {}
 
     // Price filter based on normalized fields
-    if (price_min !== undefined || price_max !== undefined) {
-      const min = price_min
-      const max = price_max
-      where.AND = (where.AND || [])
-      where.AND.push({
-        OR: [
-          { tuitionMin: { gte: min, lte: max } },
-          { tuitionMax: { gte: min, lte: max } }
-        ]
-      })
+    const normalizedPriceRange = this.normalizePriceRange(price_min, price_max)
+    if (normalizedPriceRange) {
+      const priceConditions: Prisma.UniversityWhereInput[] = []
+
+      if (normalizedPriceRange.min !== undefined && normalizedPriceRange.max !== undefined) {
+        priceConditions.push(
+          { tuitionMin: { gte: normalizedPriceRange.min, lte: normalizedPriceRange.max } },
+          { tuitionMax: { gte: normalizedPriceRange.min, lte: normalizedPriceRange.max } }
+        )
+      } else if (normalizedPriceRange.min !== undefined) {
+        priceConditions.push(
+          { tuitionMin: { gte: normalizedPriceRange.min } },
+          { tuitionMax: { gte: normalizedPriceRange.min } }
+        )
+      } else if (normalizedPriceRange.max !== undefined) {
+        priceConditions.push(
+          { tuitionMin: { lte: normalizedPriceRange.max } },
+          { tuitionMax: { lte: normalizedPriceRange.max } }
+        )
+      }
+
+      if (priceConditions.length > 0) {
+        where.AND = (where.AND || [])
+        where.AND.push({ OR: priceConditions })
+      }
     }
 
     // Search by title/description translations and city name translations
@@ -288,6 +303,29 @@ export class UniversityRepository {
       data: prioritized,
       total,
       filters
+    }
+  }
+
+  private normalizePriceRange(min?: number, max?: number): { min?: number; max?: number } | null {
+    const hasValidMin = typeof min === 'number' && Number.isFinite(min) && min >= 0
+    const hasValidMax = typeof max === 'number' && Number.isFinite(max) && max >= 0
+
+    if (!hasValidMin && !hasValidMax) {
+      return null
+    }
+
+    let normalizedMin = hasValidMin ? min : undefined
+    let normalizedMax = hasValidMax ? max : undefined
+
+    if (normalizedMin !== undefined && normalizedMax !== undefined && normalizedMin > normalizedMax) {
+      const temp = normalizedMin
+      normalizedMin = normalizedMax
+      normalizedMax = temp
+    }
+
+    return {
+      min: normalizedMin,
+      max: normalizedMax
     }
   }
 

--- a/tests/server/api/v1/universities/university.repository.spec.ts
+++ b/tests/server/api/v1/universities/university.repository.spec.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PrismaClient } from '@prisma/client'
+
+import { UniversityRepository } from '../../../../../server/repositories/UniversityRepository'
+import { parseUniversityFilters } from '../../../../../server/utils/api-helpers'
+
+const createPrismaMock = () => {
+  const findMany = vi.fn().mockResolvedValue([])
+  const count = vi.fn().mockResolvedValue(0)
+  const groupBy = vi.fn().mockResolvedValue([])
+  const aggregate = vi.fn().mockResolvedValue({ _min: {}, _max: {} })
+  const academicProgramGroupBy = vi.fn().mockResolvedValue([])
+  const cityTranslationFindMany = vi.fn().mockResolvedValue([])
+  const transaction = vi.fn(async (queries: Promise<unknown>[]) => Promise.all(queries))
+
+  const prisma = {
+    university: {
+      findMany,
+      count,
+      groupBy,
+      aggregate
+    },
+    academicProgram: {
+      groupBy: academicProgramGroupBy
+    },
+    cityTranslation: {
+      findMany: cityTranslationFindMany
+    },
+    $transaction: transaction
+  } as unknown as PrismaClient
+
+  return {
+    prisma,
+    findMany,
+    count,
+    groupBy,
+    aggregate,
+    academicProgramGroupBy,
+    cityTranslationFindMany,
+    transaction
+  }
+}
+
+describe('UniversityRepository price filtering', () => {
+  let prismaMock: ReturnType<typeof createPrismaMock>
+  let repository: UniversityRepository
+
+  beforeEach(() => {
+    prismaMock = createPrismaMock()
+    repository = new UniversityRepository(prismaMock.prisma)
+  })
+
+  it('does not apply price filter when parameters are missing', async () => {
+    const filters = parseUniversityFilters({})
+
+    await repository.findAll(filters, 'ru')
+
+    const args = prismaMock.findMany.mock.calls[0][0]
+    expect(args.where?.AND).toBeUndefined()
+  })
+
+  it('ignores non-numeric values while keeping valid bounds', async () => {
+    const filters = parseUniversityFilters({ price_min: 'abc', price_max: '3000' })
+
+    await repository.findAll(filters, 'ru')
+
+    const args = prismaMock.findMany.mock.calls[0][0]
+    expect(args.where?.AND?.[0]?.OR).toEqual([
+      { tuitionMin: { lte: 3000 } },
+      { tuitionMax: { lte: 3000 } }
+    ])
+  })
+
+  it('drops negative numbers from filters', async () => {
+    const filters = parseUniversityFilters({ price_min: '-10', price_max: '2000' })
+
+    await repository.findAll(filters, 'ru')
+
+    const args = prismaMock.findMany.mock.calls[0][0]
+    expect(args.where?.AND?.[0]?.OR).toEqual([
+      { tuitionMin: { lte: 2000 } },
+      { tuitionMax: { lte: 2000 } }
+    ])
+  })
+
+  it('normalizes inverted ranges by swapping min and max', async () => {
+    await repository.findAll({ price_min: 5000, price_max: 2000 }, 'ru')
+
+    const args = prismaMock.findMany.mock.calls[0][0]
+    expect(args.where?.AND?.[0]?.OR).toEqual([
+      { tuitionMin: { gte: 2000, lte: 5000 } },
+      { tuitionMax: { gte: 2000, lte: 5000 } }
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- normalize `parseUniversityFilters` to drop missing or invalid values and keep pagination optional
- guard price filtering in `UniversityRepository` with validated ranges and align default pagination handling
- add Vitest coverage for the repository price filter edge cases

## Testing
- npx vitest run tests/server/api/v1/universities/university.repository.spec.ts
- npm run test -- --run *(fails: existing suite relies on globals like `readonly` and missing aliases)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5e347bf0833382136a2c106f19db