### PR TITLE
Refine Bitrix messenger payload validation and config parsing

### DIFF
--- a/server/api/v1/messenger-events.post.ts
+++ b/server/api/v1/messenger-events.post.ts
@@ -1,5 +1,6 @@
 import { BitrixService } from '../../services/BitrixService'
 import { getBitrixConfig } from '../../utils/bitrix-config'
+import type { MessengerEventUtm } from '../../services/bitrix.dto'
 
 interface MessengerEventRequestBody {
   channel?: string
@@ -9,17 +10,60 @@ interface MessengerEventRequestBody {
   metadata?: Record<string, unknown>
 }
 
-const sanitizeUtmPayload = (utm: MessengerEventRequestBody['utm']): Record<string, string> => {
+type UtmCandidate = {
+  utm_source?: unknown
+  utm_medium?: unknown
+  utm_campaign?: unknown
+  utm_content?: unknown
+  utm_term?: unknown
+}
+
+const sanitizeUtmPayload = (utm: MessengerEventRequestBody['utm']): MessengerEventUtm | undefined => {
   if (!utm || typeof utm !== 'object') {
-    return {}
+    return undefined
   }
 
-  return Object.entries(utm).reduce<Record<string, string>>((acc, [key, value]) => {
-    if (typeof value === 'string' && value.length > 0) {
-      acc[key] = value
+  const candidate = utm as UtmCandidate
+  const sanitized: MessengerEventUtm = {}
+
+  if (typeof candidate.utm_source === 'string') {
+    const value = candidate.utm_source.trim()
+    if (value) {
+      sanitized.utm_source = value
     }
-    return acc
-  }, {})
+  }
+
+  if (typeof candidate.utm_medium === 'string') {
+    const value = candidate.utm_medium.trim()
+    if (value) {
+      sanitized.utm_medium = value
+    }
+  }
+
+  if (typeof candidate.utm_campaign === 'string') {
+    const value = candidate.utm_campaign.trim()
+    if (value) {
+      sanitized.utm_campaign = value
+    }
+  }
+
+  if (typeof candidate.utm_content === 'string') {
+    const value = candidate.utm_content.trim()
+    if (value) {
+      sanitized.utm_content = value
+    }
+  }
+
+  if (typeof candidate.utm_term === 'string') {
+    const value = candidate.utm_term.trim()
+    if (value) {
+      sanitized.utm_term = value
+    }
+  }
+
+  return sanitized.utm_source || sanitized.utm_medium || sanitized.utm_campaign || sanitized.utm_content || sanitized.utm_term
+    ? sanitized
+    : undefined
 }
 
 export default defineEventHandler(async event => {
@@ -42,12 +86,16 @@ export default defineEventHandler(async event => {
   }
 
   const bitrixService = new BitrixService(getBitrixConfig())
+  const session = typeof body.session === 'string' && body.session.length > 0 ? body.session : undefined
+  const utm = sanitizeUtmPayload(body.utm)
+  const metadata = typeof body.metadata === 'object' && body.metadata ? body.metadata : undefined
+
   const result = await bitrixService.logMessengerEvent({
     channel,
     referralCode,
-    session: typeof body.session === 'string' && body.session.length > 0 ? body.session : undefined,
-    utm: sanitizeUtmPayload(body.utm),
-    metadata: typeof body.metadata === 'object' && body.metadata ? body.metadata : undefined
+    session,
+    utm,
+    metadata
   })
 
   if (!result.success) {

--- a/server/services/bitrix.dto.ts
+++ b/server/services/bitrix.dto.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod'
+
+const createStringSanitizer = (maxLength: number) =>
+  z
+    .any()
+    .transform(value => {
+      if (typeof value !== 'string') {
+        return undefined
+      }
+
+      const trimmed = value.trim()
+
+      if (trimmed.length === 0 || trimmed.length > maxLength) {
+        return undefined
+      }
+
+      return trimmed
+    })
+
+const createRequiredString = (maxLength: number) => createStringSanitizer(maxLength).pipe(z.string())
+const createOptionalString = (maxLength: number) => createStringSanitizer(maxLength).pipe(z.string().optional())
+
+export interface MessengerEventMetadata {
+  page?: string
+  section?: string
+  component?: string
+  campaign?: string
+  referrer?: string
+  notes?: string
+}
+
+const messengerEventMetadataSchemaBase = z
+  .object({
+    page: createOptionalString(200),
+    section: createOptionalString(200),
+    component: createOptionalString(200),
+    campaign: createOptionalString(200),
+    referrer: createOptionalString(200),
+    notes: createOptionalString(500)
+  })
+  .strip()
+
+export const messengerEventMetadataSchema = messengerEventMetadataSchemaBase.transform(value => {
+  const metadata: MessengerEventMetadata = {}
+
+  if (value.page) {
+    metadata.page = value.page
+  }
+  if (value.section) {
+    metadata.section = value.section
+  }
+  if (value.component) {
+    metadata.component = value.component
+  }
+  if (value.campaign) {
+    metadata.campaign = value.campaign
+  }
+  if (value.referrer) {
+    metadata.referrer = value.referrer
+  }
+  if (value.notes) {
+    metadata.notes = value.notes
+  }
+
+  return metadata
+})
+
+export interface MessengerEventUtm {
+  utm_source?: string
+  utm_medium?: string
+  utm_campaign?: string
+  utm_content?: string
+  utm_term?: string
+}
+
+const messengerEventUtmSchemaBase = z
+  .object({
+    utm_source: createOptionalString(200),
+    utm_medium: createOptionalString(200),
+    utm_campaign: createOptionalString(200),
+    utm_content: createOptionalString(200),
+    utm_term: createOptionalString(200)
+  })
+  .strip()
+
+export const messengerEventUtmSchema = messengerEventUtmSchemaBase.transform(value => {
+  const utm: MessengerEventUtm = {}
+
+  if (value.utm_source) {
+    utm.utm_source = value.utm_source
+  }
+  if (value.utm_medium) {
+    utm.utm_medium = value.utm_medium
+  }
+  if (value.utm_campaign) {
+    utm.utm_campaign = value.utm_campaign
+  }
+  if (value.utm_content) {
+    utm.utm_content = value.utm_content
+  }
+  if (value.utm_term) {
+    utm.utm_term = value.utm_term
+  }
+
+  return utm
+})
+
+const messengerEventPayloadSchemaBase = z
+  .object({
+    channel: createRequiredString(120),
+    referralCode: createRequiredString(120),
+    session: createOptionalString(200),
+    utm: messengerEventUtmSchema.optional(),
+    metadata: messengerEventMetadataSchema.optional()
+  })
+  .strip()
+
+export const messengerEventPayloadSchema = messengerEventPayloadSchemaBase.transform(value => ({
+  channel: value.channel,
+  referralCode: value.referralCode,
+  session: value.session,
+  utm: value.utm,
+  metadata: value.metadata
+}))
+
+export type MessengerEventPayload = z.input<typeof messengerEventPayloadSchema>
+export type SanitizedMessengerEventPayload = z.output<typeof messengerEventPayloadSchema>

--- a/server/types/api.ts
+++ b/server/types/api.ts
@@ -474,8 +474,16 @@ export interface ApplicationRequest {
   }
   additional_info?: string // общее поле для дополнительной информации
   source: string // источник заявки
-  user_preferences?: any // предпочтения пользователя из анкеты
+  user_preferences?: UserPreferencesDTO // предпочтения пользователя из анкеты
   referral_code?: string // New field for explicit referral tracking
+}
+
+export interface UserPreferencesDTO {
+  source?: string
+  userType?: 'student' | 'parent'
+  universityChosen?: 'yes' | 'no'
+  language?: 'turkish' | 'english' | 'both'
+  scholarship?: 'yes' | 'no'
 }
 
 export interface ApplicationResponse {

--- a/server/utils/bitrix-config.ts
+++ b/server/utils/bitrix-config.ts
@@ -1,5 +1,11 @@
 import type { BitrixConfig } from '../services/BitrixService'
 
+export interface BitrixActivityConfig {
+  ownerId?: number
+  ownerTypeId?: number
+  responsibleId?: number
+}
+
 /**
  * Получение конфигурации Bitrix из переменных окружения
  */
@@ -59,4 +65,44 @@ export function getBitrixApiUrl(method: string): string {
 
   // Default to OAuth if mode not specified
   return `https://${config.domain}/rest/${method}.json?auth=${config.accessToken}`
+}
+
+const parsePositiveInteger = (value: string | undefined, envKey: string, logger: Pick<Console, 'error'>): number | undefined => {
+  if (!value) {
+    return undefined
+  }
+
+  const numericValue = Number(value)
+
+  if (!Number.isFinite(numericValue) || !Number.isInteger(numericValue) || numericValue <= 0) {
+    logger.error(`[Bitrix] ${envKey} must be a positive integer. Received: "${value}"`)
+    return undefined
+  }
+
+  return numericValue
+}
+
+export function getBitrixActivityConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Pick<Console, 'error'> = console
+): BitrixActivityConfig {
+  const ownerId = parsePositiveInteger(env.BITRIX_ACTIVITY_OWNER_ID, 'BITRIX_ACTIVITY_OWNER_ID', logger)
+  const ownerTypeId = parsePositiveInteger(env.BITRIX_ACTIVITY_OWNER_TYPE_ID, 'BITRIX_ACTIVITY_OWNER_TYPE_ID', logger)
+  const responsibleId = parsePositiveInteger(env.BITRIX_ACTIVITY_RESPONSIBLE_ID, 'BITRIX_ACTIVITY_RESPONSIBLE_ID', logger)
+
+  const config: BitrixActivityConfig = {}
+
+  if (ownerId) {
+    config.ownerId = ownerId
+  }
+
+  if (ownerTypeId) {
+    config.ownerTypeId = ownerTypeId
+  }
+
+  if (responsibleId) {
+    config.responsibleId = responsibleId
+  }
+
+  return config
 }

--- a/tests/server/services/BitrixService.logMessengerEvent.test.ts
+++ b/tests/server/services/BitrixService.logMessengerEvent.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BitrixService } from '../../../server/services/BitrixService'
+
+describe('BitrixService.logMessengerEvent', () => {
+  const originalEnv = { ...process.env }
+  const webhookUrl = 'https://example.com/rest/1/abc'
+
+  beforeEach(() => {
+    process.env.BITRIX_WEBHOOK_URL = webhookUrl
+    process.env.BITRIX_DOMAIN = 'example.com'
+    process.env.BITRIX_ACCESS_TOKEN = 'token'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetAllMocks()
+    Object.keys(process.env).forEach(key => {
+      if (!(key in originalEnv)) {
+        delete process.env[key]
+      }
+    })
+    Object.assign(process.env, originalEnv)
+    delete (global as any).fetch
+  })
+
+  it('sanitizes payload and ignores invalid activity config values', async () => {
+    process.env.BITRIX_ACTIVITY_OWNER_ID = 'invalid'
+    process.env.BITRIX_ACTIVITY_OWNER_TYPE_ID = '4'
+    process.env.BITRIX_ACTIVITY_RESPONSIBLE_ID = '12'
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ result: 321 })
+    }))
+    ;(global as any).fetch = fetchMock
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const service = new BitrixService({ domain: 'example.com', accessToken: 'token', webhookUrl })
+
+    const result = await service.logMessengerEvent({
+      channel: ' telegram ',
+      referralCode: ' ref-code ',
+      session: '   ',
+      utm: {
+        utm_source: ' Google ',
+        utm_medium: '',
+        utm_term: 42
+      } as unknown as Record<string, unknown>,
+      metadata: {
+        page: ' /contact ',
+        notes: '  custom note  ',
+        other: 'value'
+      } as unknown as Record<string, unknown>
+    })
+
+    expect(result).toEqual({ success: true, activityId: 321 })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    const body = JSON.parse((requestInit as RequestInit).body as string)
+
+    expect(body.fields.SUBJECT).toBe('Messenger click: telegram')
+    expect(body.fields.COMMUNICATIONS).toEqual([{ TYPE: 'IM', VALUE: 'telegram' }])
+    expect(body.fields.OWNER_ID).toBeUndefined()
+    expect(body.fields.OWNER_TYPE_ID).toBe(4)
+    expect(body.fields.RESPONSIBLE_ID).toBe(12)
+    expect(body.fields.DESCRIPTION).toContain('Channel: telegram')
+    expect(body.fields.DESCRIPTION).not.toContain('other')
+    expect(body.fields.DESCRIPTION).not.toContain('utm_term')
+    expect(body.fields.DESCRIPTION).not.toContain('session')
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('BITRIX_ACTIVITY_OWNER_ID'))
+  })
+
+  it('returns failure when payload validation fails', async () => {
+    const fetchMock = vi.fn()
+    ;(global as any).fetch = fetchMock
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const service = new BitrixService({ domain: 'example.com', accessToken: 'token', webhookUrl })
+
+    const result = await service.logMessengerEvent({
+      channel: '',
+      referralCode: ''
+    } as unknown as Record<string, unknown>)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('Invalid messenger event payload')
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(consoleErrorSpy).toHaveBeenCalled()
+  })
+})

--- a/tests/server/utils/bitrix-config.test.ts
+++ b/tests/server/utils/bitrix-config.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getBitrixActivityConfig } from '../../../server/utils/bitrix-config'
+
+describe('getBitrixActivityConfig', () => {
+  it('parses valid numeric environment variables', () => {
+    const logger = { error: vi.fn() }
+    const env = {
+      BITRIX_ACTIVITY_OWNER_ID: '10',
+      BITRIX_ACTIVITY_OWNER_TYPE_ID: '1',
+      BITRIX_ACTIVITY_RESPONSIBLE_ID: '25'
+    } as NodeJS.ProcessEnv
+
+    const config = getBitrixActivityConfig(env, logger)
+
+    expect(config).toEqual({ ownerId: 10, ownerTypeId: 1, responsibleId: 25 })
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('logs errors and omits invalid values', () => {
+    const logger = { error: vi.fn() }
+    const env = {
+      BITRIX_ACTIVITY_OWNER_ID: 'abc',
+      BITRIX_ACTIVITY_OWNER_TYPE_ID: '-2'
+    } as NodeJS.ProcessEnv
+
+    const config = getBitrixActivityConfig(env, logger)
+
+    expect(config).toEqual({})
+    expect(logger.error).toHaveBeenCalledTimes(2)
+    expect(logger.error).toHaveBeenNthCalledWith(1, expect.stringContaining('BITRIX_ACTIVITY_OWNER_ID'))
+    expect(logger.error).toHaveBeenNthCalledWith(2, expect.stringContaining('BITRIX_ACTIVITY_OWNER_TYPE_ID'))
+  })
+})


### PR DESCRIPTION
## Summary
- add DTO schemas for messenger messenger events and questionnaire preferences used when sending Bitrix leads
- sanitize and validate messenger activity payloads before calling Bitrix, while typing the CRM fields explicitly
- parse Bitrix activity configuration from the environment with logging and cover the new behaviour with focused vitest suites

## Testing
- npx vitest run tests/server/services/BitrixService.logMessengerEvent.test.ts tests/server/utils/bitrix-config.test.ts tests/server/api/v1/messenger-events.post.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cccb2e44088333a20c1c21870b50e6