### PR TITLE
Refactor FAQ repository typing and add tests

### DIFF
--- a/server/repositories/faqMapper.ts
+++ b/server/repositories/faqMapper.ts
@@ -1,0 +1,101 @@
+import type { Prisma } from '@prisma/client'
+import type { FAQCategory, FAQItem } from '../types/api'
+
+export type FaqItemWithLocalizedRelations = Prisma.FaqItemGetPayload<{
+  include: {
+    translations: true
+    category: {
+      include: {
+        translations: true
+      }
+    }
+  }
+}>
+
+export type FaqCategoryWithLocalizedRelations = Prisma.FaqCategoryGetPayload<{
+  include: {
+    translations: true
+    _count: {
+      select: {
+        items: true
+      }
+    }
+  }
+}>
+
+type TranslationWithLocale = { locale: string }
+
+type FaqTranslation = FaqItemWithLocalizedRelations['translations'][number]
+type FaqCategoryTranslation = FaqCategoryWithLocalizedRelations['translations'][number]
+
+type CategoryWithTranslations = FaqItemWithLocalizedRelations['category']
+
+const pickByLocale = <T extends TranslationWithLocale>(
+  translations: T[] | undefined,
+  normalized: string
+): T | undefined => {
+  if (!translations || translations.length === 0) {
+    return undefined
+  }
+
+  return (
+    translations.find(t => t.locale === normalized) ||
+    translations.find(t => t.locale === 'ru') ||
+    translations[0]
+  )
+}
+
+const resolveCategoryName = (
+  category: CategoryWithTranslations,
+  normalized: string
+): string => {
+  const translation = pickByLocale<FaqCategoryTranslation>(category?.translations, normalized)
+  return translation?.name || ''
+}
+
+const calculateRelevance = (translation: FaqTranslation | undefined, q?: string): number | undefined => {
+  if (!q || !translation) {
+    return undefined
+  }
+
+  const searchTerm = q.toLowerCase()
+  const questionScore = translation.question?.toLowerCase().includes(searchTerm) ? 1 : 0
+  const answerScore = translation.answer?.toLowerCase().includes(searchTerm) ? 0.5 : 0
+
+  const score = questionScore + answerScore
+  return score > 0 ? score : undefined
+}
+
+export const mapFaqItemToApi = (
+  faq: FaqItemWithLocalizedRelations,
+  normalized: string,
+  q?: string
+): FAQItem => {
+  const translation = pickByLocale<FaqTranslation>(faq.translations, normalized)
+  const categoryName = resolveCategoryName(faq.category, normalized)
+  const relevanceScore = calculateRelevance(translation, q)
+
+  return {
+    id: faq.id,
+    question: translation?.question || '',
+    answer: translation?.answer || '',
+    category: categoryName,
+    featured: faq.featured,
+    order: 0,
+    relevance_score: relevanceScore
+  }
+}
+
+export const mapFaqCategoryToApi = (
+  category: FaqCategoryWithLocalizedRelations,
+  normalized: string
+): FAQCategory => {
+  const translation = pickByLocale<FaqCategoryTranslation>(category.translations, normalized)
+
+  return {
+    key: String(category.id),
+    name: translation?.name || String(category.id),
+    count: category._count?.items ?? 0
+  }
+}
+

--- a/tests/server/FAQRepository.spec.ts
+++ b/tests/server/FAQRepository.spec.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { PrismaClient, Prisma } from '@prisma/client'
+
+import { FAQRepository } from '../../server/repositories/FAQRepository'
+import type {
+  FaqCategoryWithLocalizedRelations,
+  FaqItemWithLocalizedRelations
+} from '../../server/repositories/faqMapper'
+
+const createFaqFixtures = () => {
+  const now = new Date('2024-01-01T00:00:00.000Z')
+
+  const categoryTranslations: FaqCategoryWithLocalizedRelations['translations'] = [
+    { id: 301, categoryId: 10, locale: 'kk', name: 'KK Category', createdAt: now, updatedAt: now },
+    { id: 302, categoryId: 10, locale: 'ru', name: 'RU Category', createdAt: now, updatedAt: now }
+  ]
+
+  const categoryForItem: NonNullable<FaqItemWithLocalizedRelations['category']> = {
+    id: 10,
+    createdAt: now,
+    updatedAt: now,
+    translations: categoryTranslations
+  }
+
+  const categoryWithCount: FaqCategoryWithLocalizedRelations = {
+    id: categoryForItem.id,
+    createdAt: categoryForItem.createdAt,
+    updatedAt: categoryForItem.updatedAt,
+    translations: categoryTranslations,
+    _count: { items: 2 }
+  }
+
+  const questionTranslations: FaqItemWithLocalizedRelations['translations'] = [
+    {
+      id: 401,
+      faqId: 1,
+      locale: 'kk',
+      question: 'Visa requirements for students',
+      answer: 'Толық түсіндірме',
+      createdAt: now,
+      updatedAt: now
+    },
+    {
+      id: 402,
+      faqId: 1,
+      locale: 'ru',
+      question: 'Визовые требования',
+      answer: 'Подробный ответ',
+      createdAt: now,
+      updatedAt: now
+    }
+  ]
+
+  const answerTranslations: FaqItemWithLocalizedRelations['translations'] = [
+    {
+      id: 501,
+      faqId: 2,
+      locale: 'kk',
+      question: 'How to apply',
+      answer: 'Visa assistance guidance',
+      createdAt: now,
+      updatedAt: now
+    },
+    {
+      id: 502,
+      faqId: 2,
+      locale: 'ru',
+      question: 'Как подать документы',
+      answer: 'Информация о визе',
+      createdAt: now,
+      updatedAt: now
+    }
+  ]
+
+  const faqQuestionMatch: FaqItemWithLocalizedRelations = {
+    id: 1,
+    categoryId: 10,
+    featured: false,
+    createdAt: now,
+    updatedAt: now,
+    translations: questionTranslations,
+    category: categoryForItem
+  }
+
+  const faqAnswerMatch: FaqItemWithLocalizedRelations = {
+    id: 2,
+    categoryId: 10,
+    featured: true,
+    createdAt: now,
+    updatedAt: now,
+    translations: answerTranslations,
+    category: categoryForItem
+  }
+
+  return {
+    faqQuestionMatch,
+    faqAnswerMatch,
+    categoryWithCount
+  }
+}
+
+describe('FAQRepository', () => {
+  describe('findAll', () => {
+    it('applies localized search filters and sorts results by relevance', async () => {
+      const { faqQuestionMatch, faqAnswerMatch, categoryWithCount } = createFaqFixtures()
+
+      const findMany = vi.fn().mockResolvedValue([faqAnswerMatch, faqQuestionMatch])
+      const count = vi.fn().mockResolvedValueOnce(2).mockResolvedValueOnce(5)
+      const categoryFindMany = vi.fn().mockResolvedValue([categoryWithCount])
+      const transaction = vi.fn(async (operations: Array<Promise<unknown>>) => Promise.all(operations))
+
+      const prisma = {
+        faqItem: {
+          findMany,
+          count
+        },
+        faqCategory: {
+          findMany: categoryFindMany
+        },
+        $transaction: transaction
+      } as unknown as PrismaClient
+
+      const repository = new FAQRepository(prisma)
+      const result = await repository.findAll({ q: 'Visa', limit: 10 }, 'kz')
+
+      expect(transaction).toHaveBeenCalledTimes(1)
+      expect(findMany).toHaveBeenCalledTimes(1)
+      expect(count).toHaveBeenCalledTimes(2)
+      expect(categoryFindMany).toHaveBeenCalledTimes(1)
+
+      const [findManyArgs] = findMany.mock.calls[0] as [Prisma.FaqItemFindManyArgs]
+      const include = findManyArgs.include as Prisma.FaqItemInclude
+      const translationInclude = include?.translations as Prisma.FaqTranslationFindManyArgs
+      const where = findManyArgs.where as Prisma.FaqItemWhereInput
+      const translationFilter = where?.translations?.some as Prisma.FaqTranslationWhereInput
+
+      expect(findManyArgs.take).toBe(10)
+      expect(translationInclude?.where?.locale?.in).toEqual(['kk', 'kz', 'ru'])
+      expect(translationFilter?.OR).toEqual([
+        { question: { contains: 'Visa' } },
+        { answer: { contains: 'Visa' } }
+      ])
+
+      expect(result.data.map(item => item.id)).toEqual([1, 2])
+      expect(result.data.map(item => item.relevance_score)).toEqual([1, 0.5])
+      expect(result.data[0].category).toBe('KK Category')
+      expect(result.categories).toEqual([
+        { key: '10', name: 'KK Category', count: 2 }
+      ])
+      expect(result.meta).toEqual({ total: 5, filtered: 2, query: 'Visa' })
+    })
+  })
+
+  describe('search', () => {
+    it('sorts items by relevance when searching with locale fallbacks', async () => {
+      const { faqQuestionMatch, faqAnswerMatch } = createFaqFixtures()
+
+      const findMany = vi.fn().mockResolvedValue([faqAnswerMatch, faqQuestionMatch])
+      const prisma = {
+        faqItem: {
+          findMany
+        },
+        faqCategory: {
+          findMany: vi.fn()
+        },
+        $transaction: vi.fn()
+      } as unknown as PrismaClient
+
+      const repository = new FAQRepository(prisma)
+      const result = await repository.search('Visa', 'kk', 2)
+
+      const [findManyArgs] = findMany.mock.calls[0] as [Prisma.FaqItemFindManyArgs]
+      const include = findManyArgs.include as Prisma.FaqItemInclude
+      const translationInclude = include?.translations as Prisma.FaqTranslationFindManyArgs
+      const searchFilter = findManyArgs.where?.translations?.some as Prisma.FaqTranslationWhereInput
+
+      expect(findManyArgs.take).toBe(2)
+      expect(translationInclude?.where?.locale?.in).toEqual(['kk', 'kz', 'ru'])
+      expect(searchFilter?.OR).toEqual([
+        { question: { contains: 'Visa' } },
+        { answer: { contains: 'Visa' } }
+      ])
+
+      expect(result.map(item => item.id)).toEqual([1, 2])
+      expect(result.map(item => item.relevance_score)).toEqual([1, 0.5])
+    })
+  })
+})
+


### PR DESCRIPTION
## Summary
- replace FAQ repository helpers to use Prisma types and move mapping into a dedicated mapper module
- remove unsafe any casts, type the category fetch, and reuse the mapper across queries and mutations
- add FAQ repository tests that verify localized search filters and relevance sorting

## Testing
- npm run test -- FAQRepository.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cccb2d86ec83338dbcfccc21d283f3