### PR TITLE
Handle missing Bitrix configuration in messenger events

### DIFF
--- a/server/api/v1/messenger-events.post.ts
+++ b/server/api/v1/messenger-events.post.ts
@@ -1,5 +1,5 @@
 import { BitrixService } from '../../services/BitrixService'
-import { getBitrixConfig } from '../../utils/bitrix-config'
+import { getBitrixConfig, validateBitrixConfig } from '../../utils/bitrix-config'
 import type { MessengerEventUtm } from '../../services/bitrix.dto'
 
 interface MessengerEventRequestBody {
@@ -82,6 +82,14 @@ export default defineEventHandler(async event => {
     throw createError({
       statusCode: 400,
       statusMessage: 'Referral code is required'
+    })
+  }
+
+  if (!validateBitrixConfig()) {
+    console.warn('[Bitrix] Configuration is missing. Unable to log messenger event.')
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'Bitrix integration is not configured'
     })
   }
 


### PR DESCRIPTION
## Summary
- validate Bitrix configuration before instantiating the messenger events Bitrix service and return a 503 error when it is missing
- extend messenger events API tests to cover configured and non-configured Bitrix scenarios

## Testing
- npm run test -- tests/server/api/v1/messenger-events.post.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd391c0d1c8333bd6129290084d72f