### PR TITLE
Add bulk filter updates and test single route update

### DIFF
--- a/app/components/features/universities/discovery/FilterPanel.vue
+++ b/app/components/features/universities/discovery/FilterPanel.vue
@@ -111,7 +111,7 @@ const emit = defineEmits<{
 // Use universities store to get current filters
 const universitiesStore = useUniversitiesStore()
 const { filters, availableFilters } = storeToRefs(universitiesStore)
-const { setFilter } = universitiesStore
+const { applyFilters } = universitiesStore
 
 const state = reactive({
   q: '',
@@ -206,14 +206,16 @@ function reset() {
 
 function apply() {
   const cityValue = state.city === 'Все' ? 'Все города' : state.city
-  
+
   // Apply filters through composable which updates URL
-  setFilter('q', state.q)
-  setFilter('city', cityValue)
-  setFilter('langs', state.langs)
-  setFilter('type', state.type)
-  setFilter('level', state.level)
-  setFilter('price', priceRange.value)
+  applyFilters({
+    q: state.q,
+    city: cityValue,
+    langs: [...state.langs],
+    type: state.type,
+    level: state.level,
+    price: [priceRange.value[0], priceRange.value[1]] as [number, number]
+  })
 
   // Legacy emit for backwards compatibility
   emit('apply', {

--- a/app/stores/universities.ts
+++ b/app/stores/universities.ts
@@ -237,9 +237,20 @@ export const useUniversitiesStore = defineStore('universities', () => {
     }
   }
 
-  function setFilter<K extends keyof UniversityFilters>(key: K, value: UniversityFilters[K]) {
-    filters.value[key] = value
+  function applyFilters(newFilters: Partial<UniversityFilters>, options?: { sort?: SortOption }) {
+    (Object.entries(newFilters) as [keyof UniversityFilters, UniversityFilters[keyof UniversityFilters]][]).forEach(([key, value]) => {
+      filters.value[key] = value
+    })
+
+    if (options && 'sort' in options && options.sort !== undefined) {
+      sort.value = options.sort
+    }
+
     updateURL()
+  }
+
+  function setFilter<K extends keyof UniversityFilters>(key: K, value: UniversityFilters[K]) {
+    applyFilters({ [key]: value } as Partial<UniversityFilters>)
   }
 
   const setCityFilter = (city: string) => {
@@ -322,6 +333,7 @@ export const useUniversitiesStore = defineStore('universities', () => {
     
     // Actions
     setFilter,
+    applyFilters,
     setCityFilter,
     setCityFilterFromFooter,
     setSort,

--- a/tests/components/FilterPanel.test.ts
+++ b/tests/components/FilterPanel.test.ts
@@ -1,10 +1,30 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
 import { nextTick } from 'vue'
 import FilterPanel from '~/components/features/universities/discovery/FilterPanel.vue'
 import BaseRangeSlider from '~/components/ui/forms/BaseRangeSlider.vue'
 import { useUniversitiesStore } from '~/stores/universities'
+
+const routerReplaceMock = vi.fn(() => Promise.resolve())
+const routerPushMock = vi.fn(() => Promise.resolve())
+const routeMock = { query: {} as Record<string, unknown> }
+
+vi.stubGlobal('useRouter', () => ({
+  replace: routerReplaceMock,
+  push: routerPushMock
+}))
+
+vi.stubGlobal('useRoute', () => routeMock)
+
+;(globalThis as unknown as { requestAnimationFrame: (cb: (time: number) => void) => number }).requestAnimationFrame = (cb: (time: number) => void) => {
+  cb(0)
+  return 0
+}
+
+if (typeof window !== 'undefined') {
+  window.scrollTo = vi.fn()
+}
 
 const createStoreWithRange = (priceRange: [number, number]) => {
   const store = useUniversitiesStore()
@@ -27,9 +47,47 @@ const createStoreWithRange = (priceRange: [number, number]) => {
   return store
 }
 
+const mountFilterPanel = () => mount(FilterPanel, {
+  global: {
+    components: {
+      UiFormsBaseRangeSlider: BaseRangeSlider
+    },
+    config: {
+      globalProperties: {
+        $t: (key: string) => key
+      }
+    },
+    stubs: {
+      UiFormsBaseTextField: {
+        name: 'UiFormsBaseTextField',
+        template: '<input />',
+        props: ['modelValue']
+      },
+      UiFormsBaseSelect: {
+        name: 'UiFormsBaseSelect',
+        template: '<select><slot /></select>',
+        props: ['modelValue']
+      },
+      UiFormsBaseCheckbox: {
+        name: 'UiFormsBaseCheckbox',
+        template: '<input type="checkbox" />',
+        props: ['checked']
+      },
+      Icon: {
+        name: 'Icon',
+        template: '<span />',
+        props: ['name']
+      }
+    }
+  }
+})
+
 describe('FilterPanel', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
+    routerReplaceMock.mockClear()
+    routerPushMock.mockClear()
+    routeMock.query = {}
   })
 
   it('renders range slider with available price bounds', async () => {
@@ -37,40 +95,7 @@ describe('FilterPanel', () => {
     const updatedRange: [number, number] = [1000, 20000]
     const store = createStoreWithRange(initialRange)
 
-    const wrapper = mount(FilterPanel, {
-      global: {
-        components: {
-          UiFormsBaseRangeSlider: BaseRangeSlider
-        },
-        config: {
-          globalProperties: {
-            $t: (key: string) => key
-          }
-        },
-        stubs: {
-          UiFormsBaseTextField: {
-            name: 'UiFormsBaseTextField',
-            template: '<input />',
-            props: ['modelValue']
-          },
-          UiFormsBaseSelect: {
-            name: 'UiFormsBaseSelect',
-            template: '<select><slot /></select>',
-            props: ['modelValue']
-          },
-          UiFormsBaseCheckbox: {
-            name: 'UiFormsBaseCheckbox',
-            template: '<input type="checkbox" />',
-            props: ['checked']
-          },
-          Icon: {
-            name: 'Icon',
-            template: '<span />',
-            props: ['name']
-          }
-        }
-      }
-    })
+    const wrapper = mountFilterPanel()
 
     await nextTick()
 
@@ -101,5 +126,21 @@ describe('FilterPanel', () => {
 
     const updatedRangeDisplay = wrapper.find('span.text-gray-600')
     expect(updatedRangeDisplay.text()).toBe('$1,000 - $20,000')
+  })
+
+  it('triggers a single route update when apply is clicked', async () => {
+    createStoreWithRange([500, 15000])
+
+    const wrapper = mountFilterPanel()
+
+    await nextTick()
+
+    const applyButton = wrapper.findAll('button').find(button => button.text().includes('apply_button'))
+    expect(applyButton).toBeDefined()
+
+    await applyButton!.trigger('click')
+    await nextTick()
+
+    expect(routerReplaceMock).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- add an `applyFilters` action to update multiple filter fields and optional sort in one call
- switch `FilterPanel` bulk operations to use the new store method to limit URL updates
- enhance the FilterPanel unit test to stub routing utilities and assert a single route update occurs when applying filters

## Testing
- npm run lint *(fails: repository currently has pre-existing lint violations outside the touched files)*
- npm run test *(fails: existing unrelated test failures in the suite)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4336374083339061d4ef1ca0e07f