### PR TITLE
Update API docs for statistics and messenger events

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ npm run docker:logs  # Логи MySQL
 - `GET /api/v1/universities` — список университетов
 - `GET /api/v1/universities/[id]` — детали университета
 - `GET /api/v1/reviews` — список отзывов
-- `GET /api/v1/reviews/statistics` — статистика отзывов
+- `GET /api/v1/statistics` — статистика отзывов
 - `GET /api/v1/content/faq` — список FAQ
 - `POST /api/v1/applications` — отправка заявки (интеграция с Bitrix)
+- `POST /api/v1/messenger-events` — логирование событий в мессенджерах ([требования к payload-у](./server/services/bitrix.dto.ts))
 
 ## 🧪 Тесты
 


### PR DESCRIPTION
## Summary
- update the API documentation to reference the implemented /api/v1/statistics handler
- add the messenger events endpoint with a link to its payload requirements

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68cd50d112e48333b485682aa7e4a3b4