### PR TITLE
Remove unused actual universities field from popular programs

### DIFF
--- a/app/components/features/universities/sections/PopularProgramsSection.vue
+++ b/app/components/features/universities/sections/PopularProgramsSection.vue
@@ -93,7 +93,6 @@ import { computed, onMounted, ref } from 'vue'
 interface ProgramStats {
   universities_count: number
   price_from: number
-  actual_universities: number
   direction_slugs: string[]
 }
 

--- a/tests/components/PopularProgramsSection.test.ts
+++ b/tests/components/PopularProgramsSection.test.ts
@@ -83,37 +83,31 @@ describe('PopularProgramsSection', () => {
       it: {
         universities_count: 42,
         price_from: 3500,
-        actual_universities: 0,
         direction_slugs: []
       },
       medicine: {
         universities_count: 28,
         price_from: 8000,
-        actual_universities: 0,
         direction_slugs: []
       },
       engineering: {
         universities_count: 52,
         price_from: 4200,
-        actual_universities: 0,
         direction_slugs: []
       },
       business: {
         universities_count: 38,
         price_from: 3800,
-        actual_universities: 0,
         direction_slugs: []
       },
       design: {
         universities_count: 32,
         price_from: 5500,
-        actual_universities: 0,
         direction_slugs: []
       },
       international: {
         universities_count: 25,
         price_from: 4000,
-        actual_universities: 0,
         direction_slugs: []
       }
     }


### PR DESCRIPTION
## Summary
- remove the unused `actual_universities` property from the popular programs component types
- adjust the component test fixtures to match the API response shape

## Testing
- npm run test -- PopularProgramsSection

------
https://chatgpt.com/codex/tasks/task_e_68cd583381c88333aad9481d1999cae4