### PR TITLE
Improve tracking code randomness

### DIFF
--- a/server/utils/tracking.ts
+++ b/server/utils/tracking.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from 'node:crypto'
+
 export function generateTrackingCode(): string {
   const prefix = 'EDU'
   const timestamp = Date.now().toString(36).toUpperCase()
-  const random = Math.random().toString(36).substr(2, 4).toUpperCase()
+  const random = randomUUID().replace(/-/g, '').slice(0, 8).toUpperCase()
   return `${prefix}-${timestamp}-${random}`
 }

--- a/tests/server/tracking.test.ts
+++ b/tests/server/tracking.test.ts
@@ -11,12 +11,25 @@ describe('tracking code generation', () => {
   it('creates tracking code with EDU prefix via request helper', () => {
     const trackingCode = helperGenerateTrackingCode()
 
-    expect(trackingCode.startsWith('EDU-')).toBe(true)
+    expect(trackingCode).toMatch(/^EDU-[0-9A-Z]+-[0-9A-F]{8}$/)
 
     const parts = trackingCode.split('-')
     expect(parts).toHaveLength(3)
+    expect(parts[0]).toBe('EDU')
     expect(parts[1]).toMatch(/^[0-9A-Z]+$/)
-    expect(parts[2]).toMatch(/^[0-9A-Z]{4}$/)
+    expect(parts[2]).toHaveLength(8)
+    expect(parts[2]).toMatch(/^[0-9A-F]+$/)
+  })
+
+  it('generates sufficiently unique tracking codes', () => {
+    const iterations = 1000
+    const codes = new Set<string>()
+
+    for (let i = 0; i < iterations; i++) {
+      codes.add(helperGenerateTrackingCode())
+    }
+
+    expect(codes.size).toBe(iterations)
   })
 
   it('uses shared tracking generator in repository', async () => {


### PR DESCRIPTION
## Summary
- use the Node.js crypto module to build the random tracking code suffix
- replace deprecated substring usage with slice on the UUID-derived suffix
- extend tracking tests to cover the new format and uniqueness guarantees

## Testing
- npm run test -- tests/server/tracking.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd64913024833395d7785dec807133