### PR TITLE
Comment unused env placeholders and document status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,19 +15,19 @@ NUXT_SECRET_KEY=your_secret_key_here_change_in_production
 # JWT Configuration (if needed for authentication)
 JWT_SECRET=your_jwt_secret_key_here_change_in_production
 
-# Email Configuration (for future use)
-SMTP_HOST=
-SMTP_PORT=587
-SMTP_USER=
-SMTP_PASSWORD=
+# Email Configuration (reserved for future SMTP integration; not read by the app yet)
+# SMTP_HOST=
+# SMTP_PORT=587
+# SMTP_USER=
+# SMTP_PASSWORD=
 
-# API Configuration
-API_RATE_LIMIT=100
-API_TIMEOUT=30000
+# API Configuration (placeholders for future throttling; not read by the app yet)
+# API_RATE_LIMIT=100
+# API_TIMEOUT=30000
 
 # Logging
 LOG_LEVEL=info
-LOG_FILE_PATH=./logs/app.log
+# LOG_FILE_PATH=./logs/app.log  # Reserved for future file logging; not read by the app yet
 
 # Вариант 1: Webhook (рекомендуемый)
 BITRIX_WEBHOOK_URL="https://your-domain.bitrix24.ru/rest/1/your_webhook_key/"

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ npm run db:deploy   # применить миграции на проде
 - **Directus**: `DIRECTUS_KEY`, `DIRECTUS_SECRET`, `DIRECTUS_PUBLIC_URL`, `DIRECTUS_ADMIN_EMAIL`, `DIRECTUS_ADMIN_PASSWORD`, `DIRECTUS_STATIC_TOKEN`, `NUXT_PUBLIC_DIRECTUS_URL`.
 - **Аналитика**: `NUXT_PUBLIC_YANDEX_METRIKA_ID`.
 
+> ℹ️ Переменные `SMTP_*`, `API_RATE_LIMIT`, `API_TIMEOUT`, `LOG_FILE_PATH` сохранены в `.env.example` как задел на будущие интеграции (SMTP, лимиты API, файловый лог). Текущее приложение их не считывает, поэтому их настройка не обязательна.
+
 ```bash
 # База данных и приложение
 DATABASE_URL="mysql://user:password@host:3306/database"


### PR DESCRIPTION
## Summary
- comment SMTP, API, and log file environment placeholders in .env.example with notes that they are unused today
- document in the README that these variables are reserved for future integrations and need no configuration yet

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cd691554008333a70940c026666fc1