### PR TITLE
docs: fix import university example path

### DIFF
--- a/docs/scripts/IMPORT_UNIVERSITY.md
+++ b/docs/scripts/IMPORT_UNIVERSITY.md
@@ -19,7 +19,7 @@ CLI `scripts/import-university.ts` импортирует/обновляет о�
 npm run import:university -- /absolute/path/university.json --upsert-by=slug
 
 # Напрямую через tsx/npx
-npx tsx scripts/import-university.ts ./app/assets/json/universities/technica_university.json --upsert-by=title
+npx tsx scripts/import-university.ts ./app/assets/json/universities/atlas_university.json --upsert-by=title
 ```
 
 - `--upsert-by=slug|title` — по какому полю искать существующий университет (по умолчанию: `slug`).


### PR DESCRIPTION
## Summary
- update the direct tsx example in the import-university guide to point to an existing JSON file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd7004c30c8333a4548f9432230f80