### PR TITLE
Treat Kazakh locale like other languages

### DIFF
--- a/app/components/features/universities/sections/PopularProgramsSection.vue
+++ b/app/components/features/universities/sections/PopularProgramsSection.vue
@@ -112,6 +112,27 @@ const loading = ref(true)
 const dynamicData = ref<PopularProgramsResponse['data'] | null>(null)
 const { t, locale } = useI18n()
 
+const DEFAULT_LOCALE = 'ru'
+const CANONICAL_LOCALE_MAP: Record<string, string> = {
+  kk: 'kz'
+}
+
+const normalizeLanguageCode = (value?: string | null) => {
+  if (!value) {
+    return DEFAULT_LOCALE
+  }
+
+  const trimmed = value.trim().toLowerCase()
+
+  if (!trimmed) {
+    return DEFAULT_LOCALE
+  }
+
+  const base = trimmed.split(/[-_]/)[0]
+
+  return CANONICAL_LOCALE_MAP[base] ?? base
+}
+
 const pluralRules = computed(() => new Intl.PluralRules(locale.value))
 const currencyFormatter = computed(
   () =>
@@ -145,7 +166,7 @@ const formatPrice = (price: number) => {
 onMounted(async () => {
   try {
     const response = await $fetch<PopularProgramsResponse>('/api/v1/universities/popular-programs', {
-      query: { locale: locale.value }
+      query: { lang: normalizeLanguageCode(locale.value) }
     })
     
     if (response.success) {


### PR DESCRIPTION
## Summary
- add a shared helper that resolves language codes to canonical locale variants so Kazakh works like other languages
- ensure the popular programs endpoint always queries Prisma with normalized variants and honour both lang and locale parameters
- update the front-end request to send a canonical lang param and extend tests to cover Kazakh normalization end-to-end

## Testing
- npx vitest run tests/server/api/v1/universities/popular-programs.get.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68cd6ff206788333abcf7b6cba871daf