### PR TITLE
chore: remove redundant inline comments

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -8,7 +8,6 @@ export const prisma = globalForPrisma.prisma ?? new PrismaClient()
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
 
-// Graceful shutdown
 process.on('beforeExit', () => {
   prisma.$disconnect()
 })

--- a/server/middleware/i18n-api.ts
+++ b/server/middleware/i18n-api.ts
@@ -7,35 +7,28 @@ const SUPPORTED_LOCALES = ['en', 'ru', 'kk', 'kz', 'tr']
 const DEFAULT_LOCALE = 'ru'
 
 export default defineEventHandler(async (event) => {
-  // Skip non-API routes
   if (!event.node.req.url?.startsWith('/api/')) {
     return
   }
 
-  // Detect language from various sources
   const locale = detectLanguage(event)
-  
-  // Set context for database queries
+
   event.context.locale = locale
-  
-  // Set response headers
+
   setHeader(event, 'Content-Language', locale)
   setHeader(event, 'Vary', 'Accept-Language')
 })
 
 function detectLanguage(event: any): string {
-  // 1. Query parameter has highest priority
   const queryLang = getQuery(event).lang as string
   if (queryLang && SUPPORTED_LOCALES.includes(queryLang)) {
     return queryLang === 'kz' ? 'kk' : queryLang
   }
 
-  // 2. Accept-Language header
   const acceptLang = getHeader(event, 'Accept-Language')
   if (acceptLang) {
     const preferred = parseAcceptLanguageSimple(acceptLang)
     for (const lang of preferred) {
-      // Check both full code and base language
       const baseCode = lang.split('-')[0]
       if (SUPPORTED_LOCALES.includes(lang)) {
         return lang === 'kz' ? 'kk' : lang
@@ -46,7 +39,6 @@ function detectLanguage(event: any): string {
     }
   }
 
-  // 3. Default fallback
   return DEFAULT_LOCALE
 }
 

--- a/server/middleware/referral.ts
+++ b/server/middleware/referral.ts
@@ -1,12 +1,10 @@
 export default defineEventHandler((event) => {
-  // Check for ref parameter in URL
   const query = getQuery(event)
   const refCode = query.ref as string
-  
+
   if (refCode && /^[a-zA-Z0-9_-]+$/.test(refCode)) {
-    // Set cookie with 30-day expiration
     setCookie(event, 'referral_code', refCode, {
-      maxAge: 30 * 24 * 60 * 60, // 30 days
+      maxAge: 30 * 24 * 60 * 60,
       path: '/',
       secure: process.env.NODE_ENV === 'production',
       httpOnly: false, // accessible on client for referral tracking

--- a/server/middleware/restrict-host.ts
+++ b/server/middleware/restrict-host.ts
@@ -1,7 +1,6 @@
 import { defineEventHandler, getRequestHeader, createError } from 'h3';
 
-// Allow configuring additional hosts via env (comma-separated)
-const envHosts = (process.env.ALLOWED_HOSTS || '').split(',').map(h => h.trim().toLowerCase()).filter(Boolean)
+const envHosts = (process.env.ALLOWED_HOSTS || '').split(',').map(h => h.trim().toLowerCase()).filter(Boolean);
 const ALLOWED_HOSTS = new Set<string>([
   'localhost:3000',
   '127.0.0.1:3000',
@@ -12,7 +11,6 @@ const ALLOWED_HOSTS = new Set<string>([
 ]);
 
 export default defineEventHandler((event) => {
-  // In development, relax the restriction entirely
   if (process.env.NODE_ENV !== 'production') {
     return
   }

--- a/server/repositories/ApplicationRepository.ts
+++ b/server/repositories/ApplicationRepository.ts
@@ -9,7 +9,6 @@ export class ApplicationRepository {
    * Create a new application
    */
   async create(data: ApplicationRequest): Promise<ApplicationResponse> {
-    // Generate tracking code
     const trackingCode = generateTrackingCode()
 
     const normalizedFirstName = data.personal_info.first_name?.trim() || ''

--- a/server/types/api.ts
+++ b/server/types/api.ts
@@ -311,10 +311,10 @@ export interface UniversityResponse {
 // ==========================================
 
 export interface DirectionQueryParams {
-  q?: string           // Search query
-  page?: number        // Page number
-  limit?: number       // Items per page
-  lang?: string        // API language
+  q?: string
+  page?: number
+  limit?: number
+  lang?: string
 }
 
 export interface DirectionInfo {
@@ -408,11 +408,11 @@ export interface CreateReviewResponse {
 // ==========================================
 
 export interface FAQQueryParams {
-  q?: string           // Search query for questions and answers
-  category?: string    // Filter by category
-  featured?: boolean   // Show only featured FAQs
-  limit?: number       // Number of results
-  lang?: string        // API language
+  q?: string
+  category?: string
+  featured?: boolean
+  limit?: number
+  lang?: string
 }
 
 // Simplified FAQ data structure - using plain HTML strings for answers

--- a/server/utils/api-helpers.ts
+++ b/server/utils/api-helpers.ts
@@ -216,7 +216,6 @@ export function getFAQCategories(faqs: FAQItem[]): FAQCategory[] {
     { key: 'all', name: 'All Questions', count: faqs.length }
   ]
   
-  // Add specific categories
   const categoryNames: Record<string, string> = {
     'documents': 'Documents and Application',
     'exams': 'Exams and Testing',
@@ -265,8 +264,6 @@ export function validateApplicationData(data: any): { isValid: boolean; errors: 
     errors.push('First name is required')
   }
   
-  // Last name is optional
-  // Email is optional, but if provided validate format
   if (data.personal_info?.email?.trim()) {
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.personal_info.email)) {
       errors.push('Invalid email format')
@@ -280,8 +277,6 @@ export function validateApplicationData(data: any): { isValid: boolean; errors: 
   if (!data.education?.level?.trim()) {
     errors.push('Education level is required')
   }
-  
-  // Universities preference is optional
   
   return {
     isValid: errors.length === 0,


### PR DESCRIPTION
## Summary
- remove redundant inline comments from API type definitions and validators
- clean up middleware and repository files by dropping comments that restate the code
- tidy Prisma client bootstrap by dropping unnecessary shutdown comment

## Testing
- npm run lint *(fails: existing lint warnings/errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7aa4b5808333a143b2ddb26eb8f4