### PR TITLE
Fix runtime when app directory is bind-mounted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,11 +58,14 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends netcat-openbsd openssl ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-# Copy production node_modules from builder (already pruned)
-COPY --from=builder /app/node_modules ./node_modules
+# Copy runtime dependencies and build artefacts to a persistent location
+RUN mkdir -p /opt/nuxt
+COPY --from=builder /app/node_modules /opt/nuxt/node_modules
+COPY --from=builder /app/.output /opt/nuxt/.output
 
-# Copy build artefacts and runtime files
-COPY --from=builder /app/.output ./.output
+# Expose them inside the working directory (keeps compatibility for plain images)
+RUN ln -s /opt/nuxt/node_modules /app/node_modules \
+  && ln -s /opt/nuxt/.output /app/.output
 COPY prisma ./prisma
 COPY package.json ./
 

--- a/contrib/entrypoint.sh
+++ b/contrib/entrypoint.sh
@@ -1,6 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Helper to ensure we have access to build artefacts even if /app is bind-mounted
+restore_link() {
+  local source="$1"
+  local dest="$2"
+  local sentinel="$3"
+
+  if [[ -n "$sentinel" && -e "${dest}/${sentinel}" ]]; then
+    return 0
+  fi
+
+  if [[ ! -e "$source" ]]; then
+    return 1
+  fi
+
+  if [[ -e "$dest" || -L "$dest" ]]; then
+    rm -rf "$dest"
+  fi
+
+  ln -s "$source" "$dest"
+}
+
+# Restore node_modules and Nitro output if they vanished because of a bind mount
+restore_link /opt/nuxt/node_modules /app/node_modules ".bin/nuxt" || true
+restore_link /opt/nuxt/.output /app/.output "server/index.mjs" || true
+
+# If Nitro output is still missing, perform a build (last resort for fresh mounts)
+if [[ ! -f /app/.output/server/index.mjs ]]; then
+  echo "[entrypoint] .output not found. Running npm run build to regenerate it..."
+  npm run build
+fi
+
 # Ensure Prisma Client is available (safe if already generated)
 if [[ -f prisma/schema.prisma ]]; then
   npx prisma generate --schema=prisma/schema.prisma >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- store built Nitro output and pruned node_modules under /opt/nuxt inside the image
- expose them in /app via symlinks so bind mounts can be repaired at runtime
- enhance the entrypoint to restore the symlinks or rebuild the output when missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1775da8588333808c9cd59ba37cdf