### PR TITLE
refactor: split FAQ helpers from api utilities

### DIFF
--- a/server/api/v1/content/faq.get.ts
+++ b/server/api/v1/content/faq.get.ts
@@ -1,7 +1,7 @@
 import { prisma } from '~~/lib/prisma'
 import { FAQRepository } from '~~/server/repositories'
 import type { FAQResponse } from '~~/server/types/api'
-import { parseFAQFilters } from '~~/server/utils/api-helpers'
+import { parseFAQFilters } from '~~/server/utils/faq-helpers'
 
 export default defineEventHandler(async (event): Promise<FAQResponse> => {
   try {

--- a/server/utils/api-helpers.ts
+++ b/server/utils/api-helpers.ts
@@ -1,4 +1,4 @@
-import type { FAQItem, FAQCategory, UniversityQueryParams } from '~~/server/types/api'
+import type { UniversityQueryParams } from '~~/server/types/api'
 import { parsePositiveInt } from '~~/lib/number'
 
 /**
@@ -140,105 +140,6 @@ export function parseReviewFilters(query: Record<string, any>) {
     ...(lang ? { lang } : {}),
     ...(mediaType ? { mediaType } : {}),
   }
-}
-
-/**
- * Parse query parameters for FAQ endpoint
- */
-export function parseFAQFilters(query: Record<string, any>) {
-  const lang = typeof query.lang === 'string' ? query.lang.trim() : ''
-
-  return {
-    q: (query.q as string) || '',
-    category: (query.category as string) || 'all',
-    featured: query.featured === 'true',
-    limit: toPositiveIntegerWithDefault(query.limit, 50),
-    ...(lang ? { lang } : {}),
-  }
-}
-
-/**
- * Search FAQs by query string with relevance scoring
- * Updated to handle simplified string answers
- */
-export function searchFAQs(faqs: FAQItem[], searchQuery: string): FAQItem[] {
-  if (!searchQuery.trim()) {
-    return faqs
-  }
-
-  const query = searchQuery.toLowerCase()
-  const searchTerms = query.split(' ').filter((term) => term.length > 1)
-
-  return faqs
-    .map((faq) => {
-      let score = 0
-      const questionLower = faq.question.toLowerCase()
-      const answerText = faq.answer.toLowerCase()
-
-      // Exact phrase match in question (highest score)
-      if (questionLower.includes(query)) {
-        score += 100
-      }
-
-      // Exact phrase match in answer (strip HTML tags for search)
-      const plainTextAnswer = answerText.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ')
-      if (plainTextAnswer.includes(query)) {
-        score += 50
-      }
-
-      // Individual term matches
-      searchTerms.forEach((term) => {
-        if (questionLower.includes(term)) {
-          score += 20
-        }
-        if (plainTextAnswer.includes(term)) {
-          score += 10
-        }
-      })
-
-      // Boost featured items slightly
-      if (faq.featured) {
-        score += 5
-      }
-
-      return { ...faq, relevance_score: score }
-    })
-    .filter((faq) => faq.relevance_score > 0)
-    .sort((a, b) => (b.relevance_score || 0) - (a.relevance_score || 0))
-}
-
-/**
- * Get FAQ categories with counts
- */
-export function getFAQCategories(faqs: FAQItem[]): FAQCategory[] {
-  const categoryMap = new Map<string, number>()
-
-  faqs.forEach((faq) => {
-    const count = categoryMap.get(faq.category) || 0
-    categoryMap.set(faq.category, count + 1)
-  })
-
-  const categories: FAQCategory[] = [{ key: 'all', name: 'All Questions', count: faqs.length }]
-
-  const categoryNames: Record<string, string> = {
-    documents: 'Documents and Application',
-    exams: 'Exams and Testing',
-    admission: 'Admission Process',
-    scholarships: 'Scholarships and Financial Aid',
-    languages: 'Language Requirements',
-  }
-
-  Array.from(categoryMap.entries()).forEach(([key, count]) => {
-    if (categoryNames[key]) {
-      categories.push({
-        key,
-        name: categoryNames[key],
-        count,
-      })
-    }
-  })
-
-  return categories
 }
 
 /**

--- a/server/utils/faq-helpers.ts
+++ b/server/utils/faq-helpers.ts
@@ -1,0 +1,107 @@
+import type { FAQCategory, FAQItem } from '~~/server/types/api'
+import { parsePositiveInt } from '~~/lib/number'
+
+const toPositiveIntegerWithDefault = (value: unknown, defaultValue: number) => {
+  const candidate = Array.isArray(value) ? value[0] : value
+  const parsed = parsePositiveInt(candidate)
+  return parsed ?? defaultValue
+}
+
+/**
+ * Parse query parameters for FAQ endpoint
+ */
+export function parseFAQFilters(query: Record<string, any>) {
+  const lang = typeof query.lang === 'string' ? query.lang.trim() : ''
+
+  return {
+    q: (query.q as string) || '',
+    category: (query.category as string) || 'all',
+    featured: query.featured === 'true',
+    limit: toPositiveIntegerWithDefault(query.limit, 50),
+    ...(lang ? { lang } : {}),
+  }
+}
+
+/**
+ * Search FAQs by query string with relevance scoring
+ * Updated to handle simplified string answers
+ */
+export function searchFAQs(faqs: FAQItem[], searchQuery: string): FAQItem[] {
+  if (!searchQuery.trim()) {
+    return faqs
+  }
+
+  const query = searchQuery.toLowerCase()
+  const searchTerms = query.split(' ').filter((term) => term.length > 1)
+
+  return faqs
+    .map((faq) => {
+      let score = 0
+      const questionLower = faq.question.toLowerCase()
+      const answerText = faq.answer.toLowerCase()
+
+      // Exact phrase match in question (highest score)
+      if (questionLower.includes(query)) {
+        score += 100
+      }
+
+      // Exact phrase match in answer (strip HTML tags for search)
+      const plainTextAnswer = answerText.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ')
+      if (plainTextAnswer.includes(query)) {
+        score += 50
+      }
+
+      // Individual term matches
+      searchTerms.forEach((term) => {
+        if (questionLower.includes(term)) {
+          score += 20
+        }
+        if (plainTextAnswer.includes(term)) {
+          score += 10
+        }
+      })
+
+      // Boost featured items slightly
+      if (faq.featured) {
+        score += 5
+      }
+
+      return { ...faq, relevance_score: score }
+    })
+    .filter((faq) => faq.relevance_score > 0)
+    .sort((a, b) => (b.relevance_score || 0) - (a.relevance_score || 0))
+}
+
+/**
+ * Get FAQ categories with counts
+ */
+export function getFAQCategories(faqs: FAQItem[]): FAQCategory[] {
+  const categoryMap = new Map<string, number>()
+
+  faqs.forEach((faq) => {
+    const count = categoryMap.get(faq.category) || 0
+    categoryMap.set(faq.category, count + 1)
+  })
+
+  const categories: FAQCategory[] = [{ key: 'all', name: 'All Questions', count: faqs.length }]
+
+  const categoryNames: Record<string, string> = {
+    documents: 'Documents and Application',
+    exams: 'Exams and Testing',
+    admission: 'Admission Process',
+    scholarships: 'Scholarships and Financial Aid',
+    languages: 'Language Requirements',
+  }
+
+  Array.from(categoryMap.entries()).forEach(([key, count]) => {
+    if (categoryNames[key]) {
+      categories.push({
+        key,
+        name: categoryNames[key],
+        count,
+      })
+    }
+  })
+
+  return categories
+}

--- a/tests/server/utils/api-helpers.test.ts
+++ b/tests/server/utils/api-helpers.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  calculatePagination,
-  parseFAQFilters,
-  parseReviewFilters,
-} from '~~/server/utils/api-helpers'
+import { calculatePagination, parseReviewFilters } from '~~/server/utils/api-helpers'
+import { parseFAQFilters } from '~~/server/utils/faq-helpers'
 
 describe('parseReviewFilters', () => {
   it('returns defaults for invalid pagination values', () => {


### PR DESCRIPTION
## Summary
- extract FAQ-related parsing and utility functions into server/utils/faq-helpers.ts
- keep api helper module focused on shared pagination, validation, and filter helpers
- update API handler and unit tests to consume the new FAQ utilities

## Testing
- pnpm vitest tests/server/utils/api-helpers.test.ts *(fails: missing @nuxt/test-utils dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e44cd8e6488333a6fc631f02b218af