### PR TITLE
Normalize phone numbers before validation

### DIFF
--- a/app/composables/useFormValidation.ts
+++ b/app/composables/useFormValidation.ts
@@ -120,11 +120,19 @@ export const useFormValidation = () => {
         }
         break
 
-      case 'phone':
-        if (value && !patterns.phone.test(value)) {
-          return typeof message === 'function' ? message(value, type) : message
+      case 'phone': {
+        if (value) {
+          const normalizedValue =
+            typeof value === 'string'
+              ? value.replace(/[^\d+]/g, '')
+              : String(value)
+
+          if (!patterns.phone.test(normalizedValue)) {
+            return typeof message === 'function' ? message(value, type) : message
+          }
         }
         break
+      }
 
       case 'url':
         if (value && !patterns.url.test(value)) {

--- a/tests/composables/useFormValidation.test.ts
+++ b/tests/composables/useFormValidation.test.ts
@@ -47,6 +47,10 @@ describe('useFormValidation', () => {
       // Test valid Turkish phone
       result = await validation.validateField('phone', '+905551234567', rules)
       expect(result.isValid).toBe(true)
+
+      // Test formatted valid phone
+      result = await validation.validateField('phone', '+90 (555) 123 45 67', rules)
+      expect(result.isValid).toBe(true)
     })
 
     it('should validate minimum length correctly', async () => {


### PR DESCRIPTION
## Summary
- strip formatting characters before running the phone validation rule so formatted numbers pass
- add a unit test to ensure formatted international numbers are accepted

## Testing
- pnpm vitest --run tests/composables/useFormValidation.test.ts *(fails: ParseError: Identifier 'defineNuxtConfig' has already been declared.)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e526a46c83338f418c080b0658fc