### PR TITLE
Remove unused education column from applications

### DIFF
--- a/prisma/migrations/20251004120000_remove_application_education/migration.sql
+++ b/prisma/migrations/20251004120000_remove_application_education/migration.sql
@@ -1,0 +1,2 @@
+-- Drop unused education JSON column from applications
+ALTER TABLE `applications` DROP COLUMN `education`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -402,7 +402,6 @@ model Application {
   source         String            @db.VarChar(100) @default("unknown")
   referralCode   String?           @map("referral_code") @db.VarChar(100)
   personalInfo   Json              @map("personal_info")
-  education      Json
   preferences    Json
   additionalInfo Json?             @map("additional_info")
   submittedAt    DateTime          @default(now()) @map("submitted_at")


### PR DESCRIPTION
## Summary
- remove the unused `education` JSON field from the Prisma `Application` model
- add a migration dropping the `education` column from the `applications` table

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e514fdbf48833398720eeabf4446b6